### PR TITLE
Use YAML file for configuration

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,4 +12,11 @@ jobs:
         uses: actions/setup-python@v1
         with:
           python-version: 3.9
-      - run: python -m unittest discover -s src/ds_caselaw_utils/
+      - name: Run image
+        uses: abatilo/actions-poetry@v2.0.0
+        with:
+          poetry-version: 1.1.11
+      - name: Install libraries
+        run: poetry install
+      - name: Run tests
+        run: poetry run python -m unittest discover -s src/ds_caselaw_utils/

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ neutral_url("[2022] EAT 1")  # '/eat/2022/4'
 ## Testing
 
 ```bash
+$ poetry shell
 $ cd src/ds_caselaw_utils
 $ python -m unittest
 ```
@@ -33,7 +34,7 @@ $ python3 -m twine upload --repository testpypi dist/* --verbose
 When making a new release, update the [changelog](CHANGELOG.md) in the release
 pull request.
 
-The package will **only** be released to PyPI if the branch is tagged. A merge 
+The package will **only** be released to PyPI if the branch is tagged. A merge
 to main alone will **not** trigger a release to PyPI.
 
 To create a release:

--- a/poetry.lock
+++ b/poetry.lock
@@ -1,8 +1,31 @@
-package = []
+[[package]]
+name = "ruamel.yaml"
+version = "0.17.21"
+description = "ruamel.yaml is a YAML parser/emitter that supports roundtrip preservation of comments, seq/map flow style, and map key order"
+category = "main"
+optional = false
+python-versions = ">=3"
+
+[package.dependencies]
+"ruamel.yaml.clib" = {version = ">=0.2.6", markers = "platform_python_implementation == \"CPython\" and python_version < \"3.11\""}
+
+[package.extras]
+docs = ["ryd"]
+jinja2 = ["ruamel.yaml.jinja2 (>=0.2)"]
+
+[[package]]
+name = "ruamel.yaml.clib"
+version = "0.2.6"
+description = "C version of reader, parser and emitter for ruamel.yaml derived from libyaml"
+category = "main"
+optional = false
+python-versions = ">=3.5"
 
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.9"
-content-hash = "ce2aa767160f871dd3652615ba0a0dceb7733d62eb8cb4665b87f30a562e3adf"
+content-hash = "cbc4fe90112e5787ea36b4facd72680ee10750890f1a3074d9baec9e9497903f"
 
 [metadata.files]
+"ruamel.yaml" = []
+"ruamel.yaml.clib" = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ds_caselaw_utils"
-version = "0.1.4"
+version = "0.1.5"
 description = "Utilities for the National Archives Caselaw project"
 authors = ["David McKee <dragon@dxw.com>"]
 license = "MIT"
@@ -11,6 +11,7 @@ readme = "README.md"
 
 [tool.poetry.dependencies]
 python = "^3.9"
+"ruamel.yaml" = "^0.17.21"
 
 [tool.poetry.dev-dependencies]
 

--- a/src/ds_caselaw_utils/data/neutral_citation_regex.yaml
+++ b/src/ds_caselaw_utils/data/neutral_citation_regex.yaml
@@ -1,0 +1,14 @@
+# Reading the match_data:
+# the components of the URL for [2022] EAT 1 are the
+# 2nd, 1st and 3rd components of the neutral citation,
+# so the URL becomes eat/2022/1
+
+[
+  ['^\[(\d{4})\] (UKSC|UKPC) (\d+)$',  [2, 1, 3]],
+  ['^\[(\d{4})\] (EWCA) (Civ|Crim) (\d+)$', [2, 3, 1, 4]],
+  ['^\[(\d{4})\] (EWHC) (\d+) \((Admin|Admlty|Ch|Comm|Costs|Fam|IPEC|Pat|QB|SCCO|TCC)\)$', [2, 4, 1, 3]],
+  ['^\[(\d{4})\] (EWFC|EWCOP) (\d+)$', [2, 1, 3]],
+  ['^\[(\d{4})\] (UKUT) (\d+) \((AAC|IAC|LC|TCC)\)$', [2, 4, 1, 3]],
+  ['^\[(\d{4})\] (EAT) (\d+)$', [2, 1, 3]],
+  ['^\[(\d{4})\] (UKFTT) (\d+) \((TC|GRC)\)$', [2, 4, 1, 3]]
+]

--- a/src/ds_caselaw_utils/neutral.py
+++ b/src/ds_caselaw_utils/neutral.py
@@ -2,16 +2,22 @@
 Convert neutral Citations to URL
 """
 
+import pathlib
 import re
 
 from ruamel.yaml import YAML
 
 yaml = YAML()
-with open("data/neutral_citation_regex.yaml") as f:
+datafile = pathlib.Path(__file__).parent / "data/neutral_citation_regex.yaml"
+with open(datafile) as f:
     citation_data = yaml.load(f)
 
 
 def neutral_url(citation):
+    """Given a neutral citation such as `[2020] EAT 17`,
+    return a public-API URL like `/eat/2020/17`, or None
+    if no match is found.
+    """
     for regex, groups in citation_data:
         if match := re.match(regex, citation):
             url_components = "/".join([match.groups()[x - 1] for x in groups])

--- a/src/ds_caselaw_utils/neutral.py
+++ b/src/ds_caselaw_utils/neutral.py
@@ -4,26 +4,15 @@ Convert neutral Citations to URL
 
 import re
 
-# Reading the match_data:
-# the components of the URL for [2022] EAT 1 are the
-# 2nd, 1st and 3rd components of the neutral citation,
-# so the URL becomes eat/2022/1
+from ruamel.yaml import YAML
 
-match_data = {
-    # fmt: off
-    r"^\[(\d{4})\] (UKSC|UKPC) (\d+)$": [2, 1, 3],
-    r"^\[(\d{4})\] (EWCA) (Civ|Crim) (\d+)$": [2, 3, 1, 4],
-    r"^\[(\d{4})\] (EWHC) (\d+) \((Admin|Admlty|Ch|Comm|Costs|Fam|IPEC|Pat|QB|SCCO|TCC)\)$": [2, 4, 1, 3],  # noqa: E501
-    r"^\[(\d{4})\] (EWFC|EWCOP) (\d+)$": [2, 1, 3],
-    r"^\[(\d{4})\] (UKUT) (\d+) \((AAC|IAC|LC|TCC)\)$": [2, 4, 1, 3],
-    r"^\[(\d{4})\] (EAT) (\d+)$": [2, 1, 3],
-    r"^\[(\d{4})\] (UKFTT) (\d+) \((TC|GRC)\)$": [2, 4, 1, 3],
-    # fmt: on
-}
+yaml = YAML()
+with open("data/neutral_citation_regex.yaml") as f:
+    citation_data = yaml.load(f)
 
 
 def neutral_url(citation):
-    for regex, groups in match_data.items():
+    for regex, groups in citation_data:
         if match := re.match(regex, citation):
             url_components = "/".join([match.groups()[x - 1] for x in groups])
             return f"/{url_components}".lower()


### PR DESCRIPTION
For being able to edit the Neutral Citation code in one place, we need the data in a language-agnostic format.

JSON is awful because there's no mechanism for raw strings (where `\` is just a `\` and doesn't need escaping as `\\\`. So we use YAML instead. This does require adding a library because it's not a Python built-in.

We might choose to change where the data is stored later, but this is a useful step on the road.

(Bumps version to 0.1.5 pre-emptively)