### PR TITLE
The Queen's Bench Division is now King's Bench Division

### DIFF
--- a/src/ds_caselaw_utils/data/court_names.yaml
+++ b/src/ds_caselaw_utils/data/court_names.yaml
@@ -27,6 +27,11 @@
     link: https://www.gov.uk/courts-tribunals/queens-bench-division-of-the-high-court
     ncn: \[(\d{4})\] (EWHC) (\d+) \((QB)\)
 -
+    code: EWHC-KBD
+    name: King's Bench Division of the High Court
+    link: https://www.gov.uk/courts-tribunals/kings-bench-division-of-the-high-court
+    ncn: \[(\d{4})\] (EWHC) (\d+) \((KB)\)
+-
     code: EWHC-Chancery
     name: Chancery Division of the High Court
     link: https://www.gov.uk/courts-tribunals/chancery-division-of-the-high-court

--- a/src/ds_caselaw_utils/data/neutral_citation_regex.yaml
+++ b/src/ds_caselaw_utils/data/neutral_citation_regex.yaml
@@ -6,7 +6,7 @@
 [
   ['^\[(\d{4})\] (UKSC|UKPC) (\d+)$',  [2, 1, 3]],
   ['^\[(\d{4})\] (EWCA) (Civ|Crim) (\d+)$', [2, 3, 1, 4]],
-  ['^\[(\d{4})\] (EWHC) (\d+) \((Admin|Admlty|Ch|Comm|Costs|Fam|IPEC|Pat|QB|SCCO|TCC)\)$', [2, 4, 1, 3]],
+  ['^\[(\d{4})\] (EWHC) (\d+) \((Admin|Admlty|Ch|Comm|Costs|Fam|IPEC|Pat|QB|KB|SCCO|TCC)\)$', [2, 4, 1, 3]],
   ['^\[(\d{4})\] (EWFC|EWCOP) (\d+)$', [2, 1, 3]],
   ['^\[(\d{4})\] (UKUT) (\d+) \((AAC|IAC|LC|TCC)\)$', [2, 4, 1, 3]],
   ['^\[(\d{4})\] (EAT) (\d+)$', [2, 1, 3]],

--- a/src/ds_caselaw_utils/test_neutral.py
+++ b/src/ds_caselaw_utils/test_neutral.py
@@ -13,6 +13,7 @@ class TestNeutralURL(unittest.TestCase):
         self.assertEqual(neutral_url("[2022] EAT 1"), "/eat/2022/1")
         self.assertEqual(neutral_url("[2022] UKFTT 1 (TC)"), "/ukftt/tc/2022/1")
         self.assertEqual(neutral_url("[2022] UKFTT 1 (GRC)"), "/ukftt/grc/2022/1")
+        self.assertEqual(neutral_url("[2022] EWHC 1 (KB)"), "/ewhc/kb/2022/1")
 
     def test_bad_neutral_urls(self):
         self.assertEqual(neutral_url(""), None)


### PR DESCRIPTION
We add `2022 EWHC 4 (KB)` to the neutral citation to URL solver and update the unused list of courts.