### PR TITLE
Add helpers for accessing court metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,4 +14,7 @@ The format is based on [Keep a Changelog 1.0.0].
 ## [Release 0.1.4]
 - Initial tagged release
 
+## [Release 0.2.0]
+- Add helpers for accessing metadata about courts
+
 [keep a changelog 1.0.0]: https://keepachangelog.com/en/1.0.0/

--- a/README.md
+++ b/README.md
@@ -11,6 +11,48 @@ so that we can have a single point of truth potentially across many repositories
 ```
 from ds_caselaw_utils import neutral_url
 neutral_url("[2022] EAT 1")  # '/eat/2022/4'
+
+from ds_caselaw_utils import courts
+
+courts.get_all() # return a list of all courts
+
+courts.get_selectable() # returns a list of all courts that are whitelisted to
+                        # appear as searchable options
+
+courts.get_listable_groups() # returns a grouped list of courts that are whitelisted to
+                             # be listed publicly
+```
+
+The list of courts is defined in `src/ds_caselaw_utils/data/court_names.yml`. The format is as follows:
+
+```
+- name: high_court # Internal name of a group of courts to be displayed together
+  display_name: "High Court" # An optional public facing name for this group.
+  courts: # List of courts to be displayed under this group
+    -
+        # An internal code for this court:
+        code: EWHC-SeniorCourtsCosts
+         # The public facing name of the court:
+        name: Senior Courts Costs Office
+        # An alternative wording for use in listings (optional, defaults to `name`)
+        list_name: High Court (Senior Court Costs Office)
+        # A URL to link to for more information on this court:
+        link: https://www.gov.uk/courts-tribunals/senior-courts-costs-office
+        # A regex matching neutral citations for this court's judgments:
+        ncn: \[(\d{4})\] (EWHC) (\d+) \((SCCO)\)
+        # The canonical parameter value used in searches for this court:
+        param: 'ewhc/scco'
+        # Any additional parameter aliases which display judgments from this court:
+        extra_params: ['ewhc/costs']
+        # The year of the first judgment we have on file for this court:
+        start_year: 2003
+        # The year of the last judgment we have on file for this court
+        # (optional, defaults to current year):
+        end_year: ~
+        # Whether to expose this court publicly as selectable in search filters:
+        selectable: true
+        # Whether to expose this court publicly in listings:
+        listable: true
 ```
 
 ## Testing

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,8 @@
 [tool.poetry]
 name = "ds_caselaw_utils"
-version = "0.1.6"
+version = "0.2.0"
 description = "Utilities for the National Archives Caselaw project"
-authors = ["David McKee <dragon@dxw.com>"]
+authors = ["David McKee <dragon@dxw.com>", "Tim Cowlishaw <tim@timcowlishaw.co.uk>"]
 license = "MIT"
 homepage = "https://github.com/nationalarchives/ds-caselaw-utils"
 keywords = ["national archives", "caselaw"]

--- a/src/ds_caselaw_utils/__init__.py
+++ b/src/ds_caselaw_utils/__init__.py
@@ -1,1 +1,2 @@
 from .neutral import neutral_url as neutral_url
+from .courts import courts

--- a/src/ds_caselaw_utils/courts.py
+++ b/src/ds_caselaw_utils/courts.py
@@ -1,0 +1,56 @@
+"""
+Get metada data for the courts covered by the service
+"""
+
+import pathlib
+from ruamel.yaml import YAML
+from datetime import date
+
+class Court():
+    def __init__(self, data):
+        self.code = data.get("code")
+        self.name = data.get("name")
+        self.list_name = data.get("list_name") or data.get("name")
+        self.link = data.get("link")
+        self.ncn = data.get("ncn")
+        self.canonical_param = data.get("param")
+        self.param_aliases = [data.get("param")] + (data.get("extra_params") or [])
+        self.start_year = data.get("start_year")
+        self.end_year = data.get("end_year") or date.today().year
+
+class CourtGroup():
+    def __init__(self, name, courts):
+        self.name = name
+        self.courts = courts
+
+
+class CourtsRepository():
+    def __init__(self, data):
+        self._data = data
+
+    def get_all(self):
+        return [Court(court) for category in self._data for court in category.get("courts")]
+
+    def get_selectable(self):
+        courts = []
+        for category in self._data:
+            for court in category.get("courts"):
+                if court.get("selectable"):
+                    courts.append(Court(court))
+        return courts
+
+    def get_listable_groups(self):
+        groups = []
+        for category in self._data:
+            courts = [Court(court) for court in category.get("courts") if court.get("listable")]
+            if len(courts) > 0:
+                groups.append(CourtGroup(category.get("display_name"), courts))
+        return groups
+
+
+yaml = YAML()
+datafile = pathlib.Path(__file__).parent / "data/court_names.yaml"
+with open(datafile) as f:
+    court_data = yaml.load(f)
+
+courts = CourtsRepository(court_data)

--- a/src/ds_caselaw_utils/data/court_names.yaml
+++ b/src/ds_caselaw_utils/data/court_names.yaml
@@ -1,174 +1,381 @@
--
-    code: UKSC
-    name: The Supreme Court
-    link: https://www.supremecourt.uk/
-    ncn: \[(\d{4})\] (UKSC) (\d+)
--
-    code: UKPC
-    name: The Judicial Committee of the Privy Council
-    link: https://www.jcpc.uk/
-    ncn: \[(\d{4})\] (UKPC) \d+
--
-    code: EWCA-Criminal
-    name: Court of Appeal Criminal Division
-    link: https://www.gov.uk/courts-tribunals/court-of-appeal-criminal-division
-    ncn: \[(\d{4})\] (EWCA) (Crim) (\d+)
--
-    code: EWCA-Civil
-    name: Court of Appeal Civil Division
-    link: https://www.gov.uk/courts-tribunals/court-of-appeal-civil-division
-    ncn: \[(\d{4})\] (EWCA) (Civ) (\d+)
--
-    code: EWHC
-    name: The High Court
--
-    code: EWHC-QBD
-    name: Queen's Bench Division of the High Court
-    link: https://www.gov.uk/courts-tribunals/queens-bench-division-of-the-high-court
-    ncn: \[(\d{4})\] (EWHC) (\d+) \((QB)\)
--
-    code: EWHC-KBD
-    name: King's Bench Division of the High Court
-    link: https://www.gov.uk/courts-tribunals/kings-bench-division-of-the-high-court
-    ncn: \[(\d{4})\] (EWHC) (\d+) \((KB)\)
--
-    code: EWHC-Chancery
-    name: Chancery Division of the High Court
-    link: https://www.gov.uk/courts-tribunals/chancery-division-of-the-high-court
-    ncn: \[(\d{4})\] (EWHC) (\d+) \((Ch)\)
--
-    code: EWHC-Family
-    name: Family Division of the High Court
-    link: https://www.gov.uk/courts-tribunals/family-division-of-the-high-court
-    ncn: \[(\d{4})\] (EWHC) (\d+) \((Fam)\)
--
-    code: EWHC-QBD-Admin
-    name: Administrative Court
-    link: https://www.gov.uk/courts-tribunals/administrative-court
-    ncn: \[(\d{4})\] (EWHC) (\d+) \((Admin)\)
--
-    code: EWHC-QBD-Planning
-    name: Planning Court
-    link: https://www.gov.uk/courts-tribunals/planning-court
--
-    code: EWHC-QBD-BusinessAndProperty
-    name: The Business and Property Courts
-    link: https://www.gov.uk/courts-tribunals/the-business-and-property-courts
--
-    code: EWHC-QBD-Commercial
-    name: Commercial Court
-    link: https://www.gov.uk/courts-tribunals/commercial-court
-    ncn: \[(\d{4})\] (EWHC) (\d+) \((Comm)\)
--
-    code: EWHC-QBD-Admiralty
-    name: Admiralty Court
-    link: https://www.gov.uk/courts-tribunals/admiralty-court
-    ncn: \[(\d{4})\] (EWHC) (\d+) \((Admlty)\)
--
-    code: EWHC-QBD-TCC
-    name: Technology and Construction Court
-    link: https://www.gov.uk/courts-tribunals/technology-and-construction-court
-    ncn: \[(\d{4})\] (EWHC) (\d+) \((TCC)\)
--
-    code: EWHC-QBD-Commercial-Financial
-    name: The Financial List
-    link: https://www.gov.uk/courts-tribunals/the-financial-list
-    ncn: \[(\d{4})\] (EWHC) (\d+) \((Comm)\)
--
-    code: EWHC-QBD-Commercial-Circuit
-    name: Circuit Commercial Court
-    link: https://www.gov.uk/courts-tribunals/commercial-circuit-court
-    ncn: \[(\d{4})\] (EWHC) (\d+) \((Comm)\)
--
-    code: EWHC-Chancery-BusinessAndProperty
-    name: The Business and Property Courts
-    link: https://www.gov.uk/courts-tribunals/the-business-and-property-courts
--
-    code: EWHC-Chancery-Business
-    name: The Business List
-    link: https://www.gov.uk/courts-tribunals/the-business-list
--
-    code: EWHC-Chancery-InsolvencyAndCompanies
-    name: Insolvency and Companies List
-    link: https://www.gov.uk/courts-tribunals/insolvency-list
--
-    code: EWHC-Chancery-Financial
-    name: The Financial List
-    link: https://www.gov.uk/courts-tribunals/the-financial-list
--
-    code: EWHC-Chancery-IntellectualProperty
-    name: The Intellectual Property List
-    link: https://www.gov.uk/courts-tribunals/the-intellectual-property-list
--
-    code: EWHC-Chancery-Patents
-    name: Patents Court
-    link: https://www.gov.uk/courts-tribunals/patents-court
-    ncn: \[(\d{4})\] (EWHC) (\d+) \((Pat)\)
--
-    code: EWHC-Chancery-PropertyTrustsProbate
-    name: The Property, Trusts and Probate List
-    link: https://www.gov.uk/courts-tribunals/the-property-trusts-and-probate-list
+- name: supreme_court
+  display_name: ~
+  courts:
+    -
+        code: UKSC
+        name: United Kingdom Supreme Court
+        link: https://www.supremecourt.uk/
+        ncn: \[(\d{4})\] (UKSC) (\d+)
+        param: 'uksc'
+        start_year: '2014'
+        end_year: ~
+        selectable: true
+        listable: true
+- name: privy_council
+  display_name: ~
+  courts:
+    -
+        code: UKPC
+        name: Privy Council
+        link: https://www.jcpc.uk/
+        ncn: \[(\d{4})\] (UKPC) \d+
+        param: 'ukpc'
+        start_year: '2014'
+        end_year: ~
+        selectable: true
+        listable: true
+- name: court_of_appeal
+  display_name: "Court of Appeal"
+  courts:
+    -
+        code: EWCA-Civil
+        name: Court of Appeal Civil Division
+        list_name: "Court of Appeal (Civil Division)"
+        link: https://www.gov.uk/courts-tribunals/court-of-appeal-civil-division
+        ncn: \[(\d{4})\] (EWCA) (Civ) (\d+)
+        param: 'ecwa/civ'
+        start_year: '2003'
+        end_year: ~
+        selectable: true
+        listable: true
+    -
+        code: EWCA-Criminal
+        name: Court of Appeal Criminal Division
+        list_name: Court of Appeal (Criminal Division)
+        link: https://www.gov.uk/courts-tribunals/court-of-appeal-criminal-division
+        ncn: \[(\d{4})\] (EWCA) (Crim) (\d+)
+        param: 'ecwa/crim'
+        start_year: '2003'
+        end_year: ~
+        selectable: true
+        listable: true
+- name: high_court
+  display_name: "High Court"
+  courts:
+    -
+        code: EWHC-QBD-Admin
+        name: Administrative Court
+        list_name: High Court (Administrative Court)
+        link: https://www.gov.uk/courts-tribunals/administrative-court
+        ncn: \[(\d{4})\] (EWHC) (\d+) \((Admin)\)
+        param: 'ewhc/admin'
+        start_year: 2003
+        end_year: ~
+        selectable: true
+        listable: true
+    -
+        code: EWHC-QBD-Admiralty
+        name: Admiralty Court
+        list_name: High Court (Admiralty Division)
+        link: https://www.gov.uk/courts-tribunals/admiralty-court
+        ncn: \[(\d{4})\] (EWHC) (\d+) \((Admlty)\)
+        param: 'ewhc/admlty'
+        start_year: 2003
+        end_year: ~
+        selectable: true
+        listable: true
+    -
+        code: EWHC-Chancery
+        name: Chancery Division of the High Court
+        list_name: High Court (Chancery Division)
+        link: https://www.gov.uk/courts-tribunals/chancery-division-of-the-high-court
+        ncn: \[(\d{4})\] (EWHC) (\d+) \((Ch)\)
+        param: 'ewhc/ch'
+        start_year: 2003
+        end_year: ~
+        selectable: true
+        listable: true
+    -
+        code: EWHC-QBD-Commercial
+        name: Commercial Court
+        list_name: High Court (Commercial Court)
+        link: https://www.gov.uk/courts-tribunals/commercial-court
+        ncn: \[(\d{4})\] (EWHC) (\d+) \((Comm)\)
+        param: 'ewhc/comm'
+        start_year: 2003
+        end_year: ~
+        selectable: true
+        listable: true
+    -
+        code: EWHC-SeniorCourtsCosts
+        name: Senior Courts Costs Office
+        list_name: High Court (Senior Court Costs Office)
+        link: https://www.gov.uk/courts-tribunals/senior-courts-costs-office
+        ncn: \[(\d{4})\] (EWHC) (\d+) \((SCCO)\)
+        param: 'ewhc/scco'
+        extra_params: ['ewhc/costs']
+        start_year: 2003
+        end_year: ~
+        selectable: true
+        listable: true
+    -
+        code: EWHC-Family
+        name: Family Division of the High Court
+        list_name: High Court (Family Division)
+        link: https://www.gov.uk/courts-tribunals/family-division-of-the-high-court
+        ncn: \[(\d{4})\] (EWHC) (\d+) \((Fam)\)
+        param: 'ewhc/fam'
+        start_year: 2003
+        end_year: ~
+        selectable: true
+        listable: true
+    -
+        code: EWHC-Chancery-IPEC
+        name: Intellectual Property Enterprise Court
+        link: https://www.gov.uk/courts-tribunals/intellectual-property-enterprise-court
+        ncn: \[(\d{4})\] (EWHC) (\d+) \((IPEC)\)
+        param: 'ewhc/ipec'
+        start_year: 2003
+        end_year: ~
+        selectable: true
+        listable: true
+    -
+        code: EWHC-Mercantile
+        name: Mercantile Court
+        list_name: High Court (Mercantile Court)
+        link: https://www.gov.uk/courts-tribunals/intellectual-property-enterprise-court
+        ncn: \[(\d{4})\] (EWHC) (\d+) \((IPEC)\)
+        param: 'ewhc/mercantile'
+        start_year: 2008
+        end_year: 2014
+        selectable: true
+        listable: true
+    -
+        code: EWHC-Chancery-Patents
+        name: Patents Court
+        list_name: High Court (Patents Court)
+        link: https://www.gov.uk/courts-tribunals/patents-court
+        ncn: \[(\d{4})\] (EWHC) (\d+) \((Pat)\)
+        param: 'ewhc/pat'
+        start_year: 2003
+        end_year: ~
+        selectable: true
+        listable: true
+    -
+        code: EWHC-KBD
+        name: King's / Queen's Bench Division of the High Court
+        link: https://www.gov.uk/courts-tribunals/kings-bench-division-of-the-high-court
+        ncn: \[(\d{4})\] (EWHC) (\d+) \((KB)\)
+        param: "ewhc/kb"
+        extra_params: ["ewhc/qb"]
+        start_year: 2003
+        end_year: ~
+        selectable: true
+        listable: false
+    -
+        code: EWHC-QBD
+        name: High Court (Queen's Bench Division)
+        link: https://www.gov.uk/courts-tribunals/queens-bench-division-of-the-high-court
+        ncn: \[(\d{4})\] (EWHC) (\d+) \((QB)\)
+        param: 'ewhc/qb'
+        start_year: 2003
+        end_year: 2022
+        selectable: false
+        listable: true
+    -
+        code: EWHC-KBD
+        name: High Court (King's Bench Division)
+        link: https://www.gov.uk/courts-tribunals/kings-bench-division-of-the-high-court
+        ncn: \[(\d{4})\] (EWHC) (\d+) \((KB)\)
+        param: "ewhc/kb"
+        start_year: 2022
+        end_year: ~
+        selectable: false
+        listable: true
+    -
+        code: EWHC-QBD-TCC
+        name: Technology and Construction Court
+        list_name: High Court (Technology and Construction Court)
+        link: https://www.gov.uk/courts-tribunals/technology-and-construction-court
+        ncn: \[(\d{4})\] (EWHC) (\d+) \((TCC)\)
+        param: 'ewhc/tcc'
+        start_year: 2003
+        end_year: ~
+        selectable: true
+        listable: true
+    -
+        code: EWCOP
+        name: Court of Protection
+        link: https://www.gov.uk/courts-tribunals/court-of-protection
+        ncn: \[(\d{4})\] (EWCOP) (\d+)
+        param: 'ewcop'
+        start_year: 2009
+        end_year: ~
+        selectable: true
+        listable: true
+    -
+        code: EWFC
+        name: Family Court
+        link: https://www.judiciary.uk/you-and-the-judiciary/going-to-court/family-law-courts/
+        ncn: \[(\d{4})\] (EWFC) (\d+)
+        param: 'ewfc'
+        start_year: 2009
+        end_year: ~
+        selectable: true
+        listable: true
+    -
+        code: EWHC-QBD-Planning
+        name: Planning Court
+        link: https://www.gov.uk/courts-tribunals/planning-court
+        selectable: false
+        listable: false
+    -
+        code: EWHC-QBD-BusinessAndProperty
+        name: The Business and Property Courts
+        link: https://www.gov.uk/courts-tribunals/the-business-and-property-courts
+        selectable: false
+        listable: false
 
--
-    code: EWHC-Chancery-IPEC
-    name: Intellectual Property Enterprise Court
-    link: https://www.gov.uk/courts-tribunals/intellectual-property-enterprise-court
-    ncn: \[(\d{4})\] (EWHC) (\d+) \((IPEC)\)
--
-    code: EWHC-Chancery-Appeals
-    name: Chancery Appeals
-    link: https://www.gov.uk/courts-tribunals/chancery-division-of-the-high-court
--
-    code: EWHC-SeniorCourtsCosts
-    name: Senior Courts Costs Office
-    link: https://www.gov.uk/courts-tribunals/senior-courts-costs-office
-    ncn: \[(\d{4})\] (EWHC) (\d+) \((SCCO)\)
--
-    code: EWCOP
-    name: Court of Protection
-    link: https://www.gov.uk/courts-tribunals/court-of-protection
-    ncn: \[(\d{4})\] (EWCOP) (\d+)
--
-    code: EWFC
-    name: The Family Court
-    link: https://www.judiciary.uk/you-and-the-judiciary/going-to-court/family-law-courts/
-    ncn: \[(\d{4})\] (EWFC) (\d+)
--
-    code: UKUT-AAC
-    name: Upper Tribunal (Administrative Appeals Chamber)
-    link: https://www.gov.uk/courts-tribunals/upper-tribunal-administrative-appeals-chamber
-    ncn: \[(\d{4})\] (UKUT) (\d+) \((AAC)\)
--
-    code: UKUT-IAC
-    name: Upper Tribunal (Immigration and Asylum Chamber)
-    link: https://www.gov.uk/courts-tribunals/upper-tribunal-immigration-and-asylum-chamber
-    ncn: \[(\d{4})\] (UKUT) (\d+) \((IAC)\)
--
-    code: UKUT-LC
-    name: Upper Tribunal (Lands Chamber)
-    link: https://www.gov.uk/courts-tribunals/upper-tribunal-lands-chamber
-    ncn: \[(\d{4})\] (UKUT) (\d+) \((LC)\)
--
-    code: UKUT-TCC
-    name: Upper Tribunal (Tax and Chancery Chamber)
-    link: https://www.gov.uk/courts-tribunals/upper-tribunal-tax-and-chancery-chamber
-    ncn: \[(\d{4})\] (UKUT) (\d+) \((TCC)\)
--
-    code: EAT
-    name: Employment Appeal Tribunal
-    link: https://www.gov.uk/courts-tribunals/employment-appeal-tribunal
-    ncn: \[(\d{4})\] (EAT) (\d+)
--
-    code: UKFTT-TC
-    name: First-tier Tribunal (Tax)
-    link: https://www.gov.uk/courts-tribunals/first-tier-tribunal-tax
-    ncn: \[(\d{4})\] (UKFTT) (\d+) \((TC)\)
--
-    code: UKFTT-GRC
-    name: First-tier Tribunal (General Regulatory Chamber)
-    link: https://www.gov.uk/courts-tribunals/first-tier-tribunal-general-regulatory-chamber
-    ncn: \[(\d{4})\] (UKFTT) (\d+) \((GRC)\)
--
-    code: ET
-    name: Employment Tribunal
-    link: https://www.gov.uk/courts-tribunals/employment-tribunal
+    -
+        code: EWHC-QBD-Commercial-Financial
+        name: The Financial List
+        link: https://www.gov.uk/courts-tribunals/the-financial-list
+        ncn: \[(\d{4})\] (EWHC) (\d+) \((Comm)\)
+        selectable: false
+        listable: false
+    -
+        code: EWHC-QBD-Commercial-Circuit
+        name: Circuit Commercial Court
+        link: https://www.gov.uk/courts-tribunals/commercial-circuit-court
+        ncn: \[(\d{4})\] (EWHC) (\d+) \((Comm)\)
+        selectable: false
+        listable: false
+    -
+        code: EWHC-Chancery-BusinessAndProperty
+        name: The Business and Property Courts
+        link: https://www.gov.uk/courts-tribunals/the-business-and-property-courts
+        selectable: false
+        listable: false
+    -
+        code: EWHC-Chancery-Business
+        name: The Business List
+        link: https://www.gov.uk/courts-tribunals/the-business-list
+        selectable: false
+        listable: false
+    -
+        code: EWHC-Chancery-InsolvencyAndCompanies
+        name: Insolvency and Companies List
+        link: https://www.gov.uk/courts-tribunals/insolvency-list
+        selectable: false
+        listable: false
+    -
+        code: EWHC-Chancery-Financial
+        name: The Financial List
+        link: https://www.gov.uk/courts-tribunals/the-financial-list
+        selectable: false
+        listable: false
+    -
+        code: EWHC-Chancery-IntellectualProperty
+        name: The Intellectual Property List
+        link: https://www.gov.uk/courts-tribunals/the-intellectual-property-list
+        selectable: false
+        listable: false
+    -
+        code: EWHC-Chancery-Patents
+        name: Patents Court
+        link: https://www.gov.uk/courts-tribunals/patents-court
+        ncn: \[(\d{4})\] (EWHC) (\d+) \((Pat)\)
+        selectable: false
+        listable: false
+    -
+        code: EWHC-Chancery-PropertyTrustsProbate
+        name: The Property, Trusts and Probate List
+        link: https://www.gov.uk/courts-tribunals/the-property-trusts-and-probate-list
+        selectable: false
+        listable: false
+    -
+        code: EWHC-Chancery-Appeals
+        name: Chancery Appeals
+        link: https://www.gov.uk/courts-tribunals/chancery-division-of-the-high-court
+        selectable: false
+        listable: false
+- name: upper_tribunals
+  display_name: "Upper Tribunals"
+  courts:
+    -
+        code: UKUT-IAC
+        name: Upper Tribunal Immigration and Asylum Chamber
+        list_name: Upper Tribunal (Immigration and Asylum Chamber)
+        link: https://www.gov.uk/courts-tribunals/upper-tribunal-immigration-and-asylum-chamber
+        ncn: \[(\d{4})\] (UKUT) (\d+) \((IAC)\)
+        selectable: true
+        listable: true
+        param: 'ukuut-iac'
+        start_year: 2010
+        end_year: ~
+
+    -
+        code: UKUT-LC
+        name: Upper Tribunal Lands Chamber
+        list_name: Upper Tribunal (Lands Chamber)
+        link: https://www.gov.uk/courts-tribunals/upper-tribunal-lands-chamber
+        ncn: \[(\d{4})\] (UKUT) (\d+) \((LC)\)
+        selectable: true
+        listable: true
+        param: 'ukuut-lc'
+        start_year: 2015
+        end_year: ~
+    -
+        code: UKUT-TCC
+        name: Upper Tribunal Tax and Chancery Chamber
+        list_name: Upper Tribunal (Tax and Chancery Chamber)
+        link: https://www.gov.uk/courts-tribunals/upper-tribunal-tax-and-chancery-chamber
+        ncn: \[(\d{4})\] (UKUT) (\d+) \((TCC)\)
+        selectable: true
+        listable: true
+        param: 'ukuut-tcc'
+        start_year: 2017
+        end_year: ~
+    -
+        code: UKUT-AAC
+        name: Upper Tribunal Administrative Appeals Chamber
+        list_name: Upper Tribunal (Administrative Appeals Chamber)
+        link: https://www.gov.uk/courts-tribunals/upper-tribunal-administrative-appeals-chamber
+        ncn: \[(\d{4})\] (UKUT) (\d+) \((AAC)\)
+        selectable: true
+        listable: true
+        param: 'ukuut-aac'
+        start_year: 2022
+        end_year: ~
+- name: employment_appeal_tribunal
+  display_name: ~
+  courts:
+    -
+        code: EAT
+        name: Employment Appeal Tribunal
+        link: https://www.gov.uk/courts-tribunals/employment-appeal-tribunal
+        ncn: \[(\d{4})\] (EAT) (\d+)
+        selectable: true
+        listable: true
+        param: 'eat'
+        start_year: 2021
+        end_year: ~
+- name: first_tier_tribunals
+  display_name: "First-tier Tribunals"
+  courts:
+    -
+        code: UKFTT-TC
+        name: First-tier Tribunal (Tax Chamber)
+        link: https://www.gov.uk/courts-tribunals/first-tier-tribunal-tax
+        ncn: \[(\d{4})\] (UKFTT) (\d+) \((TC)\)
+        start_year: 2022
+        end_year: ~
+        selectable: false
+        listable: false
+    -
+        code: UKFTT-GRC
+        name: First-tier Tribunal (General Regulatory Chamber)
+        link: https://www.gov.uk/courts-tribunals/first-tier-tribunal-general-regulatory-chamber
+        ncn: \[(\d{4})\] (UKFTT) (\d+) \((GRC)\)
+        start_year: 2022
+        end_year: ~
+        selectable: false
+        listable: false
+    -
+        code: ET
+        name: Employment Tribunal
+        link: https://www.gov.uk/courts-tribunals/employment-tribunal
+        start_year: 2022
+        end_year: ~
+        selectable: false
+        listable: false

--- a/src/ds_caselaw_utils/test_courts.py
+++ b/src/ds_caselaw_utils/test_courts.py
@@ -1,0 +1,90 @@
+import unittest
+import pathlib
+from ruamel.yaml import YAML
+from datetime import date
+
+from .courts import courts, Court, CourtsRepository
+
+
+class TestCourtsRepository(unittest.TestCase):
+    def test_loads_selectable_courts(self):
+        data = [{
+            "name": "court_group",
+            "courts": [{
+                "name": "court1",
+                "selectable": True,
+            }, {
+                "name": "court2",
+                "selectable": False
+            }]
+        }]
+        repo = CourtsRepository(data)
+        selectable = repo.get_selectable()
+        self.assertIn("court1", [c.name for c in selectable])
+        self.assertNotIn("court2", [c.name for c in selectable])
+
+    def test_loads_listable_courts(self):
+        data = [
+            {
+                "name": "court_group1",
+                "display_name": "court group 1",
+                "courts": [{
+                    "name": "court1",
+                    "listable": True,
+                }, {
+                    "name": "court2",
+                    "listable": False
+                }]
+            }, {
+                "name": "court_group2",
+                "display_name": "court group 2",
+                "courts": [{
+                    "name": "court3",
+                    "listable": False
+                }]
+            }
+        ]
+        repo = CourtsRepository(data)
+        groups = repo.get_listable_groups()
+        self.assertIn("court group 1", [g.name for g in groups])
+        self.assertNotIn("court group 2", [g.name for g in groups])
+        self.assertIn("court1" , [c.name for g in groups for c in g.courts])
+        self.assertNotIn("court2" , [c.name for g in groups for c in g.courts])
+        self.assertNotIn("court3" , [c.name for g in groups for c in g.courts])
+
+
+
+class TestCourt(unittest.TestCase):
+    def test_list_name_explicit(self):
+        court = Court({"list_name": "court_name"})
+        self.assertEqual("court_name", court.list_name)
+
+    def test_list_name_default(self):
+        court = Court({"name": "court_name"})
+        self.assertEqual("court_name", court.list_name)
+
+    def test_param_aliases(self):
+        court = Court({"param": "param_1", "extra_params": ["param_2"]})
+        self.assertEqual(["param_1", "param_2"], court.param_aliases)
+
+    def test_end_year_explicit(self):
+        court = Court({"end_year": 1983})
+        self.assertEqual(1983, court.end_year)
+
+    def test_end_year_default(self):
+        court = Court({})
+        self.assertEqual(date.today().year, court.end_year)
+
+class TestCourts(unittest.TestCase):
+    def test_loads_court_yaml(self):
+        yaml = YAML()
+        datafile = pathlib.Path(__file__).parent / "data/court_names.yaml"
+        with open(datafile) as f:
+            court_data = yaml.load(f)
+        courts_from_yaml = []
+        for group in court_data:
+            for court in group.get("courts"):
+                courts_from_yaml.append(court)
+        for (court, data) in zip(courts.get_all(), courts_from_yaml):
+            self.assertEqual(court.name, data["name"])
+

--- a/src/ds_caselaw_utils/test_neutral.py
+++ b/src/ds_caselaw_utils/test_neutral.py
@@ -1,6 +1,6 @@
 import unittest
 
-from neutral import neutral_url
+from .neutral import neutral_url
 
 
 class TestNeutralURL(unittest.TestCase):


### PR DESCRIPTION
This adds a `courts` object which allows access to metadata about the courts whose judgments we hold, loaded from the `court_names.yml` file in the data folder. This file has been augmented with metadata used elsewhere in the app, with the aim of it being a single source of truth for information about courts used in the app.