### PR TITLE
Release/v0.3.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,4 +32,4 @@ jobs:
       - name: Install libraries
         run: poetry install
       - name: Run tests
-        run: poetry run python -m unittest discover -s src/ds_caselaw_utils/
+        run: cd src && poetry run python -m unittest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,4 +17,7 @@ The format is based on [Keep a Changelog 1.0.0].
 ## [Release 0.2.0]
 - Add helpers for accessing metadata about courts
 
+## [Release 0.3.0]
+- Add helper to access court metadata by parameter value.
+
 [keep a changelog 1.0.0]: https://keepachangelog.com/en/1.0.0/

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ from ds_caselaw_utils import courts
 
 courts.get_all() # return a list of all courts
 
+courts.get_by_param("ewhc/ch") # get a court by its parameter value
+
 courts.get_selectable() # returns a list of all courts that are whitelisted to
                         # appear as searchable options
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ds_caselaw_utils"
-version = "0.2.0"
+version = "0.3.0"
 description = "Utilities for the National Archives Caselaw project"
 authors = ["David McKee <dragon@dxw.com>", "Tim Cowlishaw <tim@timcowlishaw.co.uk>"]
 license = "MIT"

--- a/src/ds_caselaw_utils/__init__.py
+++ b/src/ds_caselaw_utils/__init__.py
@@ -1,2 +1,2 @@
-from .neutral import neutral_url as neutral_url
 from .courts import courts
+from .neutral import neutral_url as neutral_url

--- a/src/ds_caselaw_utils/courts.py
+++ b/src/ds_caselaw_utils/courts.py
@@ -3,10 +3,12 @@ Get metada data for the courts covered by the service
 """
 
 import pathlib
-from ruamel.yaml import YAML
 from datetime import date
 
-class Court():
+from ruamel.yaml import YAML
+
+
+class Court:
     def __init__(self, data):
         self.code = data.get("code")
         self.name = data.get("name")
@@ -18,18 +20,27 @@ class Court():
         self.start_year = data.get("start_year")
         self.end_year = data.get("end_year") or date.today().year
 
-class CourtGroup():
+
+class CourtGroup:
     def __init__(self, name, courts):
         self.name = name
         self.courts = courts
 
 
-class CourtsRepository():
+class CourtsRepository:
     def __init__(self, data):
         self._data = data
 
+    def get_by_param(self, param):
+        for group in self._data:
+            for court in group.get("courts"):
+                if court.get("param") == param:
+                    return Court(court)
+
     def get_all(self):
-        return [Court(court) for category in self._data for court in category.get("courts")]
+        return [
+            Court(court) for category in self._data for court in category.get("courts")
+        ]
 
     def get_selectable(self):
         courts = []
@@ -42,7 +53,11 @@ class CourtsRepository():
     def get_listable_groups(self):
         groups = []
         for category in self._data:
-            courts = [Court(court) for court in category.get("courts") if court.get("listable")]
+            courts = [
+                Court(court)
+                for court in category.get("courts")
+                if court.get("listable")
+            ]
             if len(courts) > 0:
                 groups.append(CourtGroup(category.get("display_name"), courts))
         return groups

--- a/src/ds_caselaw_utils/test_courts.py
+++ b/src/ds_caselaw_utils/test_courts.py
@@ -1,23 +1,26 @@
-import unittest
 import pathlib
-from ruamel.yaml import YAML
+import unittest
 from datetime import date
 
-from .courts import courts, Court, CourtsRepository
+from ruamel.yaml import YAML
+
+from .courts import Court, CourtsRepository, courts
 
 
 class TestCourtsRepository(unittest.TestCase):
     def test_loads_selectable_courts(self):
-        data = [{
-            "name": "court_group",
-            "courts": [{
-                "name": "court1",
-                "selectable": True,
-            }, {
-                "name": "court2",
-                "selectable": False
-            }]
-        }]
+        data = [
+            {
+                "name": "court_group",
+                "courts": [
+                    {
+                        "name": "court1",
+                        "selectable": True,
+                    },
+                    {"name": "court2", "selectable": False},
+                ],
+            }
+        ]
         repo = CourtsRepository(data)
         selectable = repo.get_selectable()
         self.assertIn("court1", [c.name for c in selectable])
@@ -28,30 +31,41 @@ class TestCourtsRepository(unittest.TestCase):
             {
                 "name": "court_group1",
                 "display_name": "court group 1",
-                "courts": [{
-                    "name": "court1",
-                    "listable": True,
-                }, {
-                    "name": "court2",
-                    "listable": False
-                }]
-            }, {
+                "courts": [
+                    {
+                        "name": "court1",
+                        "listable": True,
+                    },
+                    {"name": "court2", "listable": False},
+                ],
+            },
+            {
                 "name": "court_group2",
                 "display_name": "court group 2",
-                "courts": [{
-                    "name": "court3",
-                    "listable": False
-                }]
-            }
+                "courts": [{"name": "court3", "listable": False}],
+            },
         ]
         repo = CourtsRepository(data)
         groups = repo.get_listable_groups()
         self.assertIn("court group 1", [g.name for g in groups])
         self.assertNotIn("court group 2", [g.name for g in groups])
-        self.assertIn("court1" , [c.name for g in groups for c in g.courts])
-        self.assertNotIn("court2" , [c.name for g in groups for c in g.courts])
-        self.assertNotIn("court3" , [c.name for g in groups for c in g.courts])
+        self.assertIn("court1", [c.name for g in groups for c in g.courts])
+        self.assertNotIn("court2", [c.name for g in groups for c in g.courts])
+        self.assertNotIn("court3", [c.name for g in groups for c in g.courts])
 
+    def test_loads_court_by_param(self):
+        data = [
+            {
+                "name": "court_group1",
+                "courts": [{"param": "court1", "name": "Court 1"}],
+            },
+            {
+                "name": "court_group2",
+                "courts": [{"param": "court2", "name": "Court 2"}],
+            },
+        ]
+        repo = CourtsRepository(data)
+        self.assertEqual("Court 2", repo.get_by_param("court2").name)
 
 
 class TestCourt(unittest.TestCase):
@@ -75,6 +89,7 @@ class TestCourt(unittest.TestCase):
         court = Court({})
         self.assertEqual(date.today().year, court.end_year)
 
+
 class TestCourts(unittest.TestCase):
     def test_loads_court_yaml(self):
         yaml = YAML()
@@ -87,4 +102,3 @@ class TestCourts(unittest.TestCase):
                 courts_from_yaml.append(court)
         for (court, data) in zip(courts.get_all(), courts_from_yaml):
             self.assertEqual(court.name, data["name"])
-


### PR DESCRIPTION
## Adds method to look up court metadata by parameter name
Needed for change to the public search interface to ensure that the 'remove search filter' buttons include the full court names rather than an abbreviation.