### PR TITLE
Release/v0.4.0 - add accessors for all listable courts/tribunals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog 1.0.0].
 
+## [Release 0.4.0]
+- Add accessors to return all visible courts or tribunals ungrouped.
+
+## [Release 0.3.2]
+- Fix bug in court names - parameter values for upper tribunals were incorrect.
+
+## [Release 0.3.1]
+- Add newly supported first-tier tribunals to the court list
+
+## [Release 0.3.0]
+- Add helper to access court metadata by parameter value.
+
+## [Release 0.2.0]
+- Add helpers for accessing metadata about courts
+
 ## [Release 0.1.6]
 - Add King's Bench to NCN parser regex
 - Add github action to lint code on push
@@ -13,17 +28,5 @@ The format is based on [Keep a Changelog 1.0.0].
 
 ## [Release 0.1.4]
 - Initial tagged release
-
-## [Release 0.2.0]
-- Add helpers for accessing metadata about courts
-
-## [Release 0.3.0]
-- Add helper to access court metadata by parameter value.
-
-## [Release 0.3.1]
-- Add newly supported first-tier tribunals to the court list
-
-## [Release 0.3.2]
-- Fix bug in court names - parameter values for upper tribunals were incorrect.
 
 [keep a changelog 1.0.0]: https://keepachangelog.com/en/1.0.0/

--- a/README.md
+++ b/README.md
@@ -23,6 +23,14 @@ courts.get_selectable() # returns a list of all courts that are whitelisted to
 
 courts.get_listable_groups() # returns a grouped list of courts that are whitelisted to
                              # be listed publicly
+
+courts.get_listable_courts() # returns a list of all *courts* (ie not tribunals)
+                             # which are whitelisted to be listed publicly
+
+courts.get_listable_tribunals() # return a list of all *tribunals*  which are
+                                # whitelisted to be listed publicly
+
+
 ```
 
 The list of courts is defined in `src/ds_caselaw_utils/data/court_names.yml`. The format is as follows:
@@ -30,6 +38,7 @@ The list of courts is defined in `src/ds_caselaw_utils/data/court_names.yml`. Th
 ```
 - name: high_court # Internal name of a group of courts to be displayed together
   display_name: "High Court" # An optional public facing name for this group.
+  is_tribunal: false # Whether this group contains courts or tribunals
   courts: # List of courts to be displayed under this group
     -
         # An internal code for this court:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ds_caselaw_utils"
-version = "0.3.2"
+version = "0.4.0"
 description = "Utilities for the National Archives Caselaw project"
 authors = ["David McKee <dragon@dxw.com>", "Tim Cowlishaw <tim@timcowlishaw.co.uk>"]
 license = "MIT"

--- a/src/ds_caselaw_utils/courts.py
+++ b/src/ds_caselaw_utils/courts.py
@@ -62,6 +62,24 @@ class CourtsRepository:
                 groups.append(CourtGroup(category.get("display_name"), courts))
         return groups
 
+    def get_listable_courts(self):
+        courts = []
+        for group in self._data:
+            if not group.get("is_tribunal"):
+                for court in group.get("courts", []):
+                    if court.get("listable"):
+                        courts.append(Court(court))
+        return courts
+
+    def get_listable_tribunals(self):
+        courts = []
+        for group in self._data:
+            if group.get("is_tribunal"):
+                for court in group.get("courts", []):
+                    if court.get("listable"):
+                        courts.append(Court(court))
+        return courts
+
 
 yaml = YAML()
 datafile = pathlib.Path(__file__).parent / "data/court_names.yaml"

--- a/src/ds_caselaw_utils/data/court_names.yaml
+++ b/src/ds_caselaw_utils/data/court_names.yaml
@@ -1,5 +1,6 @@
 - name: supreme_court
   display_name: ~
+  is_tribunal: false
   courts:
     -
         code: UKSC
@@ -13,6 +14,7 @@
         listable: true
 - name: privy_council
   display_name: ~
+  is_tribunal: false
   courts:
     -
         code: UKPC
@@ -26,6 +28,7 @@
         listable: true
 - name: court_of_appeal
   display_name: "Court of Appeal"
+  is_tribunal: false
   courts:
     -
         code: EWCA-Civil
@@ -51,6 +54,7 @@
         listable: true
 - name: high_court
   display_name: "High Court"
+  is_tribunal: false
   courts:
     -
         code: EWHC-QBD-Admin
@@ -291,6 +295,7 @@
         listable: false
 - name: upper_tribunals
   display_name: "Upper Tribunals"
+  is_tribunal: true
   courts:
     -
         code: UKUT-IAC
@@ -339,6 +344,7 @@
         end_year: ~
 - name: employment_appeal_tribunal
   display_name: ~
+  is_tribunal: true
   courts:
     -
         code: EAT
@@ -352,6 +358,7 @@
         end_year: ~
 - name: first_tier_tribunals
   display_name: "First-tier Tribunals"
+  is_tribunal: true
   courts:
     -
         code: UKFTT-TC

--- a/src/ds_caselaw_utils/test_courts.py
+++ b/src/ds_caselaw_utils/test_courts.py
@@ -67,6 +67,60 @@ class TestCourtsRepository(unittest.TestCase):
         repo = CourtsRepository(data)
         self.assertEqual("Court 2", repo.get_by_param("court2").name)
 
+    def test_returns_listable_courts(self):
+        data = [
+            {
+                "name": "court_group1",
+                "is_tribunal": False,
+                "courts": [
+                    {"param": "court1", "listable": True, "name": "Court 1"},
+                    {"param": "court2", "listable": False, "name": "Court 2"},
+                ],
+            },
+            {
+                "name": "court_group2",
+                "is_tribunal": True,
+                "courts": [{"param": "court3", "listable": True, "name": "Court 3"}],
+            },
+        ]
+        repo = CourtsRepository(data)
+        self.assertIn("court1", [c.canonical_param for c in repo.get_listable_courts()])
+        self.assertNotIn(
+            "court2", [c.canonical_param for c in repo.get_listable_courts()]
+        )
+        self.assertNotIn(
+            "court3", [c.canonical_param for c in repo.get_listable_courts()]
+        )
+
+    def test_returns_listable_tribunals(self):
+        data = [
+            {
+                "name": "court_group1",
+                "is_tribunal": False,
+                "courts": [
+                    {"param": "court1", "listable": True, "name": "Court 1"},
+                ],
+            },
+            {
+                "name": "court_group2",
+                "is_tribunal": True,
+                "courts": [
+                    {"param": "court2", "listable": False, "name": "Court 2"},
+                    {"param": "court3", "listable": True, "name": "Court 3"},
+                ],
+            },
+        ]
+        repo = CourtsRepository(data)
+        self.assertNotIn(
+            "court1", [c.canonical_param for c in repo.get_listable_tribunals()]
+        )
+        self.assertNotIn(
+            "court2", [c.canonical_param for c in repo.get_listable_tribunals()]
+        )
+        self.assertIn(
+            "court3", [c.canonical_param for c in repo.get_listable_tribunals()]
+        )
+
 
 class TestCourt(unittest.TestCase):
     def test_list_name_explicit(self):


### PR DESCRIPTION
 This was an oversight on my part when i first wrote the court list class - there's one list in the public UI which still has court names hardcoded, and we want to bring them in from the list here, but we need them to be grouped slightly differently. This adds accessors to allow that!