### PR TITLE
Set the default search for all courts to be URI based, for now

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ds_caselaw_utils"
-version = "0.4.1"
+version = "0.4.2"
 description = "Utilities for the National Archives Caselaw project"
 authors = ["David McKee <dragon@dxw.com>", "Tim Cowlishaw <tim@timcowlishaw.co.uk>", "Laura Porter <laura@dxw.com>"]
 license = "MIT"

--- a/src/ds_caselaw_utils/data/court_names.yaml
+++ b/src/ds_caselaw_utils/data/court_names.yaml
@@ -305,7 +305,7 @@
         ncn: \[(\d{4})\] (UKUT) (\d+) \((IAC)\)
         selectable: true
         listable: true
-        param: 'ukut-iac'
+        param: 'ukut/iac'
         start_year: 2010
         end_year: ~
 
@@ -317,7 +317,7 @@
         ncn: \[(\d{4})\] (UKUT) (\d+) \((LC)\)
         selectable: true
         listable: true
-        param: 'ukut-lc'
+        param: 'ukut/lc'
         start_year: 2015
         end_year: ~
     -
@@ -328,7 +328,7 @@
         ncn: \[(\d{4})\] (UKUT) (\d+) \((TCC)\)
         selectable: true
         listable: true
-        param: 'ukut-tcc'
+        param: 'ukut/tcc'
         start_year: 2017
         end_year: ~
     -
@@ -339,7 +339,7 @@
         ncn: \[(\d{4})\] (UKUT) (\d+) \((AAC)\)
         selectable: true
         listable: true
-        param: 'ukut-aac'
+        param: 'ukut/aac'
         start_year: 2022
         end_year: ~
 - name: employment_appeal_tribunal
@@ -365,7 +365,7 @@
         name: First-tier Tribunal (Tax Chamber)
         link: https://www.gov.uk/courts-tribunals/first-tier-tribunal-tax
         ncn: \[(\d{4})\] (UKFTT) (\d+) \((TC)\)
-        param: 'ukftt-tc'
+        param: 'ukftt/tc'
         start_year: 2022
         end_year: ~
         selectable: true
@@ -373,7 +373,7 @@
     -
         code: UKFTT-GRC
         name: First-tier Tribunal (General Regulatory Chamber)
-        param: 'ukftt-grc'
+        param: 'ukftt/grc'
         link: https://www.gov.uk/courts-tribunals/first-tier-tribunal-general-regulatory-chamber
         ncn: \[(\d{4})\] (UKFTT) (\d+) \((GRC)\)
         start_year: 2022


### PR DESCRIPTION
We agreed that we'd use the slash-based form of the court IDs (based off neutral citations) for the search for now -- hyphen-based court IDs will still work, and we might want to move to them long-term, but whilst the identifiers are unstable a single uniform understood solution is the best approach.

Bumps version to 0.4.2; we'll need to update the public-ui's version at some point to actually get the benefits of this change.

Trello: https://trello.com/c/LBh3dBiq/81-%F0%9F%94%8D-pui-search-court-filter-standardisation-to-slashes