### PR TITLE
Fix release 0.4.5 and touch up docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,4 +47,17 @@ The format is based on [Keep a Changelog 1.0.0].
 ## [Release 0.1.4]
 - Initial tagged release
 
+[Unreleased]: https://github.com/nationalarchives/ds-caselaw-custom-api-client/compare/v0.4.5...HEAD
+[Release 0.4.5]: https://github.com/nationalarchives/ds-caselaw-custom-api-client/compare/v0.4.4...v0.4.5
+[Release 0.4.4]: https://github.com/nationalarchives/ds-caselaw-custom-api-client/compare/v0.4.3...v0.4.4
+[Release 0.4.3]: https://github.com/nationalarchives/ds-caselaw-custom-api-client/compare/v0.4.2...v0.4.3
+[Release 0.4.2]: https://github.com/nationalarchives/ds-caselaw-custom-api-client/compare/v0.4.1...v0.4.2
+[Release 0.4.1]: https://github.com/nationalarchives/ds-caselaw-custom-api-client/compare/v0.4.0...v0.4.1
+[Release 0.4.0]: https://github.com/nationalarchives/ds-caselaw-custom-api-client/compare/v0.3.2...v0.4.0
+[Release 0.3.2]: https://github.com/nationalarchives/ds-caselaw-custom-api-client/compare/v0.3.1...v0.3.2
+[Release 0.3.1]: https://github.com/nationalarchives/ds-caselaw-custom-api-client/compare/v0.3.0...v0.3.1
+[Release 0.3.0]: https://github.com/nationalarchives/ds-caselaw-custom-api-client/compare/v0.2.0...v0.3.0
+[Release 0.2.0]: https://github.com/nationalarchives/ds-caselaw-custom-api-client/compare/v0.1.6...v0.2.0
+[Release 0.1.6]: https://github.com/nationalarchives/ds-caselaw-custom-api-client/compare/v0.1.4...v0.1.6
+[Release 0.1.4]: https://github.com/nationalarchives/ds-caselaw-custom-api-client/releases/tag/v0.1.4
 [keep a changelog 1.0.0]: https://keepachangelog.com/en/1.0.0/

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ To create a release:
 
 0. Update the version number in `pyproject.toml`
 1. Create a branch `release/v{major}.{minor}.{patch}`
-2. Update changelog for the release
+2. Update `CHANGELOG.md` and `pyproject.toml` for the release
 3. Commit and push
 4. Open a PR from that branch to main
 5. Get approval on the PR

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ds_caselaw_utils"
-version = "0.4.4"
+version = "0.4.5"
 description = "Utilities for the National Archives Caselaw project"
 authors = ["Nick Jackson <nick@dxw.com>", "David McKee <dragon@dxw.com>", "Tim Cowlishaw <tim@timcowlishaw.co.uk>", "Laura Porter <laura@dxw.com>"]
 license = "MIT"


### PR DESCRIPTION
We broke the release process for 0.4.5.

Fix 0.4.5, update the docs to make it clear which files actually need updating, and fix the broken history links in the changelog.