### PR TITLE
Release/v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog 1.0.0].
 
+## [Release 0.5.0]
+- Added ability to look up court by code
+
 ## [Release 0.4.5]
 - Assorted quality of life improvements
 
@@ -47,17 +50,18 @@ The format is based on [Keep a Changelog 1.0.0].
 ## [Release 0.1.4]
 - Initial tagged release
 
-[Unreleased]: https://github.com/nationalarchives/ds-caselaw-custom-api-client/compare/v0.4.5...HEAD
-[Release 0.4.5]: https://github.com/nationalarchives/ds-caselaw-custom-api-client/compare/v0.4.4...v0.4.5
-[Release 0.4.4]: https://github.com/nationalarchives/ds-caselaw-custom-api-client/compare/v0.4.3...v0.4.4
-[Release 0.4.3]: https://github.com/nationalarchives/ds-caselaw-custom-api-client/compare/v0.4.2...v0.4.3
-[Release 0.4.2]: https://github.com/nationalarchives/ds-caselaw-custom-api-client/compare/v0.4.1...v0.4.2
-[Release 0.4.1]: https://github.com/nationalarchives/ds-caselaw-custom-api-client/compare/v0.4.0...v0.4.1
-[Release 0.4.0]: https://github.com/nationalarchives/ds-caselaw-custom-api-client/compare/v0.3.2...v0.4.0
-[Release 0.3.2]: https://github.com/nationalarchives/ds-caselaw-custom-api-client/compare/v0.3.1...v0.3.2
-[Release 0.3.1]: https://github.com/nationalarchives/ds-caselaw-custom-api-client/compare/v0.3.0...v0.3.1
-[Release 0.3.0]: https://github.com/nationalarchives/ds-caselaw-custom-api-client/compare/v0.2.0...v0.3.0
-[Release 0.2.0]: https://github.com/nationalarchives/ds-caselaw-custom-api-client/compare/v0.1.6...v0.2.0
-[Release 0.1.6]: https://github.com/nationalarchives/ds-caselaw-custom-api-client/compare/v0.1.4...v0.1.6
-[Release 0.1.4]: https://github.com/nationalarchives/ds-caselaw-custom-api-client/releases/tag/v0.1.4
+[Unreleased]: https://github.com/nationalarchives/ds-caselaw-utils/compare/v0.5.0...HEAD
+[Release 0.5.0]: https://github.com/nationalarchives/ds-caselaw-utils/compare/v0.4.5...v0.5.0
+[Release 0.4.5]: https://github.com/nationalarchives/ds-caselaw-utils/compare/v0.4.4...v0.4.5
+[Release 0.4.4]: https://github.com/nationalarchives/ds-caselaw-utils/compare/v0.4.3...v0.4.4
+[Release 0.4.3]: https://github.com/nationalarchives/ds-caselaw-utils/compare/v0.4.2...v0.4.3
+[Release 0.4.2]: https://github.com/nationalarchives/ds-caselaw-utils/compare/v0.4.1...v0.4.2
+[Release 0.4.1]: https://github.com/nationalarchives/ds-caselaw-utils/compare/v0.4.0...v0.4.1
+[Release 0.4.0]: https://github.com/nationalarchives/ds-caselaw-utils/compare/v0.3.2...v0.4.0
+[Release 0.3.2]: https://github.com/nationalarchives/ds-caselaw-utils/compare/v0.3.1...v0.3.2
+[Release 0.3.1]: https://github.com/nationalarchives/ds-caselaw-utils/compare/v0.3.0...v0.3.1
+[Release 0.3.0]: https://github.com/nationalarchives/ds-caselaw-utils/compare/v0.2.0...v0.3.0
+[Release 0.2.0]: https://github.com/nationalarchives/ds-caselaw-utils/compare/v0.1.6...v0.2.0
+[Release 0.1.6]: https://github.com/nationalarchives/ds-caselaw-utils/compare/v0.1.4...v0.1.6
+[Release 0.1.4]: https://github.com/nationalarchives/ds-caselaw-utils/releases/tag/v0.1.4
 [keep a changelog 1.0.0]: https://keepachangelog.com/en/1.0.0/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ds_caselaw_utils"
-version = "0.4.5"
+version = "0.5.0"
 description = "Utilities for the National Archives Caselaw project"
 authors = ["Nick Jackson <nick@dxw.com>", "David McKee <dragon@dxw.com>", "Tim Cowlishaw <tim@timcowlishaw.co.uk>", "Laura Porter <laura@dxw.com>"]
 license = "MIT"

--- a/src/ds_caselaw_utils/courts.py
+++ b/src/ds_caselaw_utils/courts.py
@@ -30,12 +30,19 @@ class CourtGroup:
 class CourtsRepository:
     def __init__(self, data):
         self._data = data
+        self._byParam = {}
+        self._byCode = {}
+        for group in self._data:
+            for courtData in group.get("courts"):
+                court = Court(courtData)
+                self._byParam[courtData.get("param")] = court
+                self._byCode[courtData.get("code")] = court
 
     def get_by_param(self, param):
-        for group in self._data:
-            for court in group.get("courts"):
-                if court.get("param") == param:
-                    return Court(court)
+        return self._byParam[param]
+
+    def get_by_code(self, code):
+        return self._byCode[code]
 
     def get_all(self):
         return [

--- a/src/ds_caselaw_utils/test_courts.py
+++ b/src/ds_caselaw_utils/test_courts.py
@@ -67,6 +67,20 @@ class TestCourtsRepository(unittest.TestCase):
         repo = CourtsRepository(data)
         self.assertEqual("Court 2", repo.get_by_param("court2").name)
 
+    def test_loads_court_by_code(self):
+        data = [
+            {
+                "name": "court_group1",
+                "courts": [{"code": "court1", "name": "Court 1"}],
+            },
+            {
+                "name": "court_group2",
+                "courts": [{"code": "court2", "name": "Court 2"}],
+            },
+        ]
+        repo = CourtsRepository(data)
+        self.assertEqual("Court 2", repo.get_by_code("court2").name)
+
     def test_returns_listable_courts(self):
         data = [
             {


### PR DESCRIPTION
** Don't merge me until https://github.com/nationalarchives/ds-caselaw-utils/pull/29 is merged **

# Includes the following:

**Add lookup of court by code**
In various places in the UI we need to return the full court name for a given internal court code.
This commit adds a method `courts.get_by_code()` which will return the court for a given code. We have also refactored to make sure that this method and the existing `courts.get_by_param()` run in constant time via a dictionary lookup, as this method will be used for every judgment returned in a results set, and we don't want to have to traverse the courts list each time.