### PR TITLE
Add JSON Schema to validate courts data

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -13,12 +13,12 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ "main" ]
+    branches: ["main"]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ "main" ]
+    branches: ["main"]
   schedule:
-    - cron: '44 9 * * 0'
+    - cron: "44 9 * * 0"
 
 jobs:
   analyze:
@@ -32,43 +32,42 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: [ 'python' ]
+        language: ["python"]
         # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
         # Learn more about CodeQL language support at https://aka.ms/codeql-docs/language-support
 
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v3
+      - name: Checkout repository
+        uses: actions/checkout@v3
 
-    # Initializes the CodeQL tools for scanning.
-    - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
-      with:
-        languages: ${{ matrix.language }}
-        # If you wish to specify custom queries, you can do so here or in a config file.
-        # By default, queries listed here will override any specified in a config file.
-        # Prefix the list here with "+" to use these queries and those in the config file.
+      # Initializes the CodeQL tools for scanning.
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v2
+        with:
+          languages: ${{ matrix.language }}
+          # If you wish to specify custom queries, you can do so here or in a config file.
+          # By default, queries listed here will override any specified in a config file.
+          # Prefix the list here with "+" to use these queries and those in the config file.
 
-        # Details on CodeQL's query packs refer to : https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
-        # queries: security-extended,security-and-quality
+          # Details on CodeQL's query packs refer to : https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
+          # queries: security-extended,security-and-quality
 
+      # Autobuild attempts to build any compiled languages  (C/C++, C#, Go, or Java).
+      # If this step fails, then you should remove it and run the build manually (see below)
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v2
 
-    # Autobuild attempts to build any compiled languages  (C/C++, C#, Go, or Java).
-    # If this step fails, then you should remove it and run the build manually (see below)
-    - name: Autobuild
-      uses: github/codeql-action/autobuild@v2
+      # ℹ️ Command-line programs to run using the OS shell.
+      # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
 
-    # ℹ️ Command-line programs to run using the OS shell.
-    # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
+      #   If the Autobuild fails above, remove it and uncomment the following three lines.
+      #   modify them (or add more) to build your code if your project, please refer to the EXAMPLE below for guidance.
 
-    #   If the Autobuild fails above, remove it and uncomment the following three lines.
-    #   modify them (or add more) to build your code if your project, please refer to the EXAMPLE below for guidance.
+      # - run: |
+      #   echo "Run, Build Application using script"
+      #   ./location_of_script_within_repo/buildscript.sh
 
-    # - run: |
-    #   echo "Run, Build Application using script"
-    #   ./location_of_script_within_repo/buildscript.sh
-
-    - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
-      with:
-        category: "/language:${{matrix.language}}"
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v2
+        with:
+          category: "/language:${{matrix.language}}"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
       - id: check-yaml
 
   - repo: https://github.com/psf/black
-    rev: 23.1.0
+    rev: 23.3.0
     hooks:
       - id: black
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,6 +9,17 @@ repos:
       - id: end-of-file-fixer
       - id: check-yaml
 
+  - repo: https://github.com/python-jsonschema/check-jsonschema
+    rev: 0.23.0
+    hooks:
+      - id: check-jsonschema
+        files: ^src/ds_caselaw_utils/data/court_names.yaml$
+        args:
+          [
+            "--schemafile",
+            "src/ds_caselaw_utils/data/schema/courts.schema.json",
+          ]
+
   - repo: https://github.com/psf/black
     rev: 23.3.0
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,6 +37,12 @@ repos:
         args: ["--ignore=F401,E501", "--config=setup.cfg"]
         additional_dependencies: [flake8-isort]
 
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: v2.7.1
+    hooks:
+      - id: prettier
+        types_or: [yaml, json, markdown]
+
 # sets up .pre-commit-ci.yaml to ensure pre-commit dependencies stay up to date
 ci:
   autoupdate_schedule: weekly

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,50 +5,63 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog 1.0.0].
 
 ## [Release 1.0.1]
+
 - Add King's Bench identifiers to the court list
 
 ## [Release 1.0.0]
+
 - Raise a meaningful exception (CourtNotFoundException) when a court is not
   found for a given param or code.
 
-
 ## [Release 0.5.0]
+
 - Added ability to look up court by code
 
 ## [Release 0.4.5]
+
 - Assorted quality of life improvements
 
 ## [Release 0.4.4]
+
 - Fix all court end dates to 2022, pending ingest of judgments for 2023
   (and/or an alternative solution for accessing this metadata dynamically)
 
 ## [Release 0.4.3]
-  - Standardise documentation (README and licence)
-  - Add CodeQL configuration
-  - Add a check for secrets
+
+- Standardise documentation (README and licence)
+- Add CodeQL configuration
+- Add a check for secrets
 
 ## [Release 0.4.2]
+
 - Set the default search for all courts to be URI based, for now
 
 ## [Release 0.4.1]
+
 - Correct two canonical params for courts which were incorrect.
 
 ## [Release 0.4.0]
+
 - Add accessors to return all visible courts or tribunals ungrouped.
 
 ## [Release 0.3.2]
+
 - Fix bug in court names - parameter values for upper tribunals were incorrect.
 
 ## [Release 0.3.1]
+
 - Add newly supported first-tier tribunals to the court list
 
 ## [Release 0.3.0]
+
 - Add helper to access court metadata by parameter value.
 
 ## [Release 0.2.0]
+
 - Add helpers for accessing metadata about courts
 
 ## [Release 0.1.6]
+
 - Add King's Bench to NCN parser regex
 - Add github action to lint code on push
 - Add court names and documentation
@@ -56,21 +69,22 @@ The format is based on [Keep a Changelog 1.0.0].
 - Use Poetry for test workflow
 
 ## [Release 0.1.4]
+
 - Initial tagged release
 
-[Unreleased]: https://github.com/nationalarchives/ds-caselaw-utils/compare/v1.0.0...HEAD
-[Release 0.5.0]: https://github.com/nationalarchives/ds-caselaw-utils/compare/v0.5.0...v1.0.0
-[Release 0.5.0]: https://github.com/nationalarchives/ds-caselaw-utils/compare/v0.4.5...v0.5.0
-[Release 0.4.5]: https://github.com/nationalarchives/ds-caselaw-utils/compare/v0.4.4...v0.4.5
-[Release 0.4.4]: https://github.com/nationalarchives/ds-caselaw-utils/compare/v0.4.3...v0.4.4
-[Release 0.4.3]: https://github.com/nationalarchives/ds-caselaw-utils/compare/v0.4.2...v0.4.3
-[Release 0.4.2]: https://github.com/nationalarchives/ds-caselaw-utils/compare/v0.4.1...v0.4.2
-[Release 0.4.1]: https://github.com/nationalarchives/ds-caselaw-utils/compare/v0.4.0...v0.4.1
-[Release 0.4.0]: https://github.com/nationalarchives/ds-caselaw-utils/compare/v0.3.2...v0.4.0
-[Release 0.3.2]: https://github.com/nationalarchives/ds-caselaw-utils/compare/v0.3.1...v0.3.2
-[Release 0.3.1]: https://github.com/nationalarchives/ds-caselaw-utils/compare/v0.3.0...v0.3.1
-[Release 0.3.0]: https://github.com/nationalarchives/ds-caselaw-utils/compare/v0.2.0...v0.3.0
-[Release 0.2.0]: https://github.com/nationalarchives/ds-caselaw-utils/compare/v0.1.6...v0.2.0
-[Release 0.1.6]: https://github.com/nationalarchives/ds-caselaw-utils/compare/v0.1.4...v0.1.6
-[Release 0.1.4]: https://github.com/nationalarchives/ds-caselaw-utils/releases/tag/v0.1.4
+[unreleased]: https://github.com/nationalarchives/ds-caselaw-utils/compare/v1.0.0...HEAD
+[release 0.5.0]: https://github.com/nationalarchives/ds-caselaw-utils/compare/v0.5.0...v1.0.0
+[release 0.5.0]: https://github.com/nationalarchives/ds-caselaw-utils/compare/v0.4.5...v0.5.0
+[release 0.4.5]: https://github.com/nationalarchives/ds-caselaw-utils/compare/v0.4.4...v0.4.5
+[release 0.4.4]: https://github.com/nationalarchives/ds-caselaw-utils/compare/v0.4.3...v0.4.4
+[release 0.4.3]: https://github.com/nationalarchives/ds-caselaw-utils/compare/v0.4.2...v0.4.3
+[release 0.4.2]: https://github.com/nationalarchives/ds-caselaw-utils/compare/v0.4.1...v0.4.2
+[release 0.4.1]: https://github.com/nationalarchives/ds-caselaw-utils/compare/v0.4.0...v0.4.1
+[release 0.4.0]: https://github.com/nationalarchives/ds-caselaw-utils/compare/v0.3.2...v0.4.0
+[release 0.3.2]: https://github.com/nationalarchives/ds-caselaw-utils/compare/v0.3.1...v0.3.2
+[release 0.3.1]: https://github.com/nationalarchives/ds-caselaw-utils/compare/v0.3.0...v0.3.1
+[release 0.3.0]: https://github.com/nationalarchives/ds-caselaw-utils/compare/v0.2.0...v0.3.0
+[release 0.2.0]: https://github.com/nationalarchives/ds-caselaw-utils/compare/v0.1.6...v0.2.0
+[release 0.1.6]: https://github.com/nationalarchives/ds-caselaw-utils/compare/v0.1.4...v0.1.6
+[release 0.1.4]: https://github.com/nationalarchives/ds-caselaw-utils/releases/tag/v0.1.4
 [keep a changelog 1.0.0]: https://keepachangelog.com/en/1.0.0/

--- a/src/ds_caselaw_utils/data/court_names.yaml
+++ b/src/ds_caselaw_utils/data/court_names.yaml
@@ -2,458 +2,411 @@
   display_name: ~
   is_tribunal: false
   courts:
-    -
-        code: UKSC
-        name: United Kingdom Supreme Court
-        link: https://www.supremecourt.uk/
-        ncn: \[(\d{4})\] (UKSC) (\d+)
-        param: 'uksc'
-        start_year: 2014
-        end_year: 2022
-        selectable: true
-        listable: true
+    - code: UKSC
+      name: United Kingdom Supreme Court
+      link: https://www.supremecourt.uk/
+      ncn: \[(\d{4})\] (UKSC) (\d+)
+      param: "uksc"
+      start_year: 2014
+      end_year: 2022
+      selectable: true
+      listable: true
 - name: privy_council
   display_name: ~
   is_tribunal: false
   courts:
-    -
-        code: UKPC
-        name: Privy Council
-        link: https://www.jcpc.uk/
-        ncn: \[(\d{4})\] (UKPC) \d+
-        param: 'ukpc'
-        start_year: 2014
-        end_year: 2022
-        selectable: true
-        listable: true
+    - code: UKPC
+      name: Privy Council
+      link: https://www.jcpc.uk/
+      ncn: \[(\d{4})\] (UKPC) \d+
+      param: "ukpc"
+      start_year: 2014
+      end_year: 2022
+      selectable: true
+      listable: true
 - name: court_of_appeal
   display_name: "Court of Appeal"
   is_tribunal: false
   courts:
-    -
-        code: EWCA-Civil
-        name: Court of Appeal Civil Division
-        list_name: "Court of Appeal (Civil Division)"
-        link: https://www.gov.uk/courts-tribunals/court-of-appeal-civil-division
-        ncn: \[(\d{4})\] (EWCA) (Civ) (\d+)
-        param: 'ewca/civ'
-        start_year: 2003
-        end_year: 2022
-        selectable: true
-        listable: true
-    -
-        code: EWCA-Criminal
-        name: Court of Appeal Criminal Division
-        list_name: Court of Appeal (Criminal Division)
-        link: https://www.gov.uk/courts-tribunals/court-of-appeal-criminal-division
-        ncn: \[(\d{4})\] (EWCA) (Crim) (\d+)
-        param: 'ewca/crim'
-        start_year: 2003
-        end_year: 2022
-        selectable: true
-        listable: true
+    - code: EWCA-Civil
+      name: Court of Appeal Civil Division
+      list_name: "Court of Appeal (Civil Division)"
+      link: https://www.gov.uk/courts-tribunals/court-of-appeal-civil-division
+      ncn: \[(\d{4})\] (EWCA) (Civ) (\d+)
+      param: "ewca/civ"
+      start_year: 2003
+      end_year: 2022
+      selectable: true
+      listable: true
+    - code: EWCA-Criminal
+      name: Court of Appeal Criminal Division
+      list_name: Court of Appeal (Criminal Division)
+      link: https://www.gov.uk/courts-tribunals/court-of-appeal-criminal-division
+      ncn: \[(\d{4})\] (EWCA) (Crim) (\d+)
+      param: "ewca/crim"
+      start_year: 2003
+      end_year: 2022
+      selectable: true
+      listable: true
 - name: high_court
   display_name: "High Court"
   is_tribunal: false
   courts:
-    -
-        code: EWHC-QBD-Admin
-        name: Administrative Court
-        list_name: High Court (Administrative Court)
-        link: https://www.gov.uk/courts-tribunals/administrative-court
-        ncn: \[(\d{4})\] (EWHC) (\d+) \((Admin)\)
-        param: 'ewhc/admin'
-        start_year: 2003
-        end_year: 2022
-        selectable: true
-        listable: true
-    -
-        code: EWHC-KBD-Admin
-        name: Administrative Court
-        list_name: High Court (Administrative Court)
-        link: https://www.gov.uk/courts-tribunals/administrative-court
-        ncn: \[(\d{4})\] (EWHC) (\d+) \((Admin)\)
-        param: 'ewhc/admin'
-        start_year: 2022
-        end_year: 2022
-        selectable: false
-        listable: false
-    -
-        code: EWHC-QBD-Admiralty
-        name: Admiralty Court
-        list_name: High Court (Admiralty Division)
-        link: https://www.gov.uk/courts-tribunals/admiralty-court
-        ncn: \[(\d{4})\] (EWHC) (\d+) \((Admlty)\)
-        param: 'ewhc/admlty'
-        start_year: 2003
-        end_year: 2022
-        selectable: true
-        listable: true
-    -
-        code: EWHC-KBD-Admiralty
-        name: Admiralty Court
-        list_name: High Court (Admiralty Division)
-        link: https://www.gov.uk/courts-tribunals/admiralty-court
-        ncn: \[(\d{4})\] (EWHC) (\d+) \((Admlty)\)
-        param: 'ewhc/admlty'
-        start_year: 2022
-        end_year: 2022
-        selectable: false
-        listable: false
-    -
-        code: EWHC-Chancery
-        name: Chancery Division of the High Court
-        list_name: High Court (Chancery Division)
-        link: https://www.gov.uk/courts-tribunals/chancery-division-of-the-high-court
-        ncn: \[(\d{4})\] (EWHC) (\d+) \((Ch)\)
-        param: 'ewhc/ch'
-        start_year: 2003
-        end_year: 2022
-        selectable: true
-        listable: true
-    -
-        code: EWHC-QBD-Commercial
-        name: Commercial Court
-        list_name: High Court (Commercial Court)
-        link: https://www.gov.uk/courts-tribunals/commercial-court
-        ncn: \[(\d{4})\] (EWHC) (\d+) \((Comm)\)
-        param: 'ewhc/comm'
-        start_year: 2003
-        end_year: 2022
-        selectable: true
-        listable: true
-    -
-        code: EWHC-KBD-Commercial
-        name: Commercial Court
-        list_name: High Court (Commercial Court)
-        link: https://www.gov.uk/courts-tribunals/commercial-court
-        ncn: \[(\d{4})\] (EWHC) (\d+) \((Comm)\)
-        param: 'ewhc/comm'
-        start_year: 2022
-        end_year: 2022
-        selectable: false
-        listable: false
-    -
-        code: EWHC-SeniorCourtsCosts
-        name: Senior Courts Costs Office
-        list_name: High Court (Senior Court Costs Office)
-        link: https://www.gov.uk/courts-tribunals/senior-courts-costs-office
-        ncn: \[(\d{4})\] (EWHC) (\d+) \((SCCO)\)
-        param: 'ewhc/scco'
-        extra_params: ['ewhc/costs']
-        start_year: 2003
-        end_year: 2022
-        selectable: true
-        listable: true
-    -
-        code: EWHC-Family
-        name: Family Division of the High Court
-        list_name: High Court (Family Division)
-        link: https://www.gov.uk/courts-tribunals/family-division-of-the-high-court
-        ncn: \[(\d{4})\] (EWHC) (\d+) \((Fam)\)
-        param: 'ewhc/fam'
-        start_year: 2003
-        end_year: 2022
-        selectable: true
-        listable: true
-    -
-        code: EWHC-Chancery-IPEC
-        name: Intellectual Property Enterprise Court
-        link: https://www.gov.uk/courts-tribunals/intellectual-property-enterprise-court
-        ncn: \[(\d{4})\] (EWHC) (\d+) \((IPEC)\)
-        param: 'ewhc/ipec'
-        start_year: 2003
-        end_year: 2022
-        selectable: true
-        listable: true
-    -
-        code: EWHC-Mercantile
-        name: Mercantile Court
-        list_name: High Court (Mercantile Court)
-        link: https://www.gov.uk/courts-tribunals/intellectual-property-enterprise-court
-        ncn: \[(\d{4})\] (EWHC) (\d+) \((IPEC)\)
-        param: 'ewhc/mercantile'
-        start_year: 2008
-        end_year: 2014
-        selectable: true
-        listable: true
-    -
-        code: EWHC-Chancery-Patents
-        name: Patents Court
-        list_name: High Court (Patents Court)
-        link: https://www.gov.uk/courts-tribunals/patents-court
-        ncn: \[(\d{4})\] (EWHC) (\d+) \((Pat)\)
-        param: 'ewhc/pat'
-        start_year: 2003
-        end_year: 2022
-        selectable: true
-        listable: true
-    -
-        code: EWHC-KBD
-        name: King's / Queen's Bench Division of the High Court
-        link: https://www.gov.uk/courts-tribunals/kings-bench-division-of-the-high-court
-        ncn: \[(\d{4})\] (EWHC) (\d+) \((KB)\)
-        param: "ewhc/kb"
-        extra_params: ["ewhc/qb"]
-        start_year: 2003
-        end_year: 2022
-        selectable: true
-        listable: false
-    -
-        code: EWHC-QBD
-        name: High Court (Queen's Bench Division)
-        link: https://www.gov.uk/courts-tribunals/queens-bench-division-of-the-high-court
-        ncn: \[(\d{4})\] (EWHC) (\d+) \((QB)\)
-        param: 'ewhc/qb'
-        start_year: 2003
-        end_year: 2022
-        selectable: false
-        listable: true
-    -
-        code: EWHC-KBD
-        name: High Court (King's Bench Division)
-        link: https://www.gov.uk/courts-tribunals/kings-bench-division-of-the-high-court
-        ncn: \[(\d{4})\] (EWHC) (\d+) \((KB)\)
-        param: "ewhc/kb"
-        start_year: 2022
-        end_year: 2022
-        selectable: false
-        listable: true
-    -
-        code: EWHC-QBD-TCC
-        name: Technology and Construction Court
-        list_name: High Court (Technology and Construction Court)
-        link: https://www.gov.uk/courts-tribunals/technology-and-construction-court
-        ncn: \[(\d{4})\] (EWHC) (\d+) \((TCC)\)
-        param: 'ewhc/tcc'
-        start_year: 2003
-        end_year: 2022
-        selectable: true
-        listable: true
-    -
-        code: EWHC-KBD-TCC
-        name: Technology and Construction Court
-        list_name: High Court (Technology and Construction Court)
-        link: https://www.gov.uk/courts-tribunals/technology-and-construction-court
-        ncn: \[(\d{4})\] (EWHC) (\d+) \((TCC)\)
-        param: 'ewhc/tcc'
-        start_year: 2022
-        end_year: 2022
-        selectable: false
-        listable: false
-    -
-        code: EWCOP
-        name: Court of Protection
-        link: https://www.gov.uk/courts-tribunals/court-of-protection
-        ncn: \[(\d{4})\] (EWCOP) (\d+)
-        param: 'ewcop'
-        start_year: 2009
-        end_year: 2022
-        selectable: true
-        listable: true
-    -
-        code: EWFC
-        name: Family Court
-        link: https://www.judiciary.uk/you-and-the-judiciary/going-to-court/family-law-courts/
-        ncn: \[(\d{4})\] (EWFC) (\d+)
-        param: 'ewfc'
-        start_year: 2009
-        end_year: 2022
-        selectable: true
-        listable: true
-    -
-        code: EWHC-QBD-Planning
-        name: Planning Court
-        link: https://www.gov.uk/courts-tribunals/planning-court
-        selectable: false
-        listable: false
-    -
-        code: EWHC-KBD-Planning
-        name: Planning Court
-        link: https://www.gov.uk/courts-tribunals/planning-court
-        selectable: false
-        listable: false
-    -
-        code: EWHC-QBD-BusinessAndProperty
-        name: The Business and Property Courts
-        link: https://www.gov.uk/courts-tribunals/the-business-and-property-courts
-        selectable: false
-        listable: false
-    -
-        code: EWHC-KBD-BusinessAndProperty
-        name: The Business and Property Courts
-        link: https://www.gov.uk/courts-tribunals/the-business-and-property-courts
-        selectable: false
-        listable: false
-    -
-        code: EWHC-QBD-Commercial-Financial
-        name: The Financial List
-        link: https://www.gov.uk/courts-tribunals/the-financial-list
-        ncn: \[(\d{4})\] (EWHC) (\d+) \((Comm)\)
-        selectable: false
-        listable: false
-    -
-        code: EWHC-KBD-Commercial-Financial
-        name: The Financial List
-        link: https://www.gov.uk/courts-tribunals/the-financial-list
-        ncn: \[(\d{4})\] (EWHC) (\d+) \((Comm)\)
-        selectable: false
-        listable: false
-    -
-        code: EWHC-QBD-Commercial-Circuit
-        name: Circuit Commercial Court
-        link: https://www.gov.uk/courts-tribunals/commercial-circuit-court
-        ncn: \[(\d{4})\] (EWHC) (\d+) \((Comm)\)
-        selectable: false
-        listable: false
-    -
-        code: EWHC-KBD-Commercial-Circuit
-        name: Circuit Commercial Court
-        link: https://www.gov.uk/courts-tribunals/commercial-circuit-court
-        ncn: \[(\d{4})\] (EWHC) (\d+) \((Comm)\)
-        selectable: false
-        listable: false
-    -
-        code: EWHC-Chancery-BusinessAndProperty
-        name: The Business and Property Courts
-        link: https://www.gov.uk/courts-tribunals/the-business-and-property-courts
-        selectable: false
-        listable: false
-    -
-        code: EWHC-Chancery-Business
-        name: The Business List
-        link: https://www.gov.uk/courts-tribunals/the-business-list
-        selectable: false
-        listable: false
-    -
-        code: EWHC-Chancery-InsolvencyAndCompanies
-        name: Insolvency and Companies List
-        link: https://www.gov.uk/courts-tribunals/insolvency-list
-        selectable: false
-        listable: false
-    -
-        code: EWHC-Chancery-Financial
-        name: The Financial List
-        link: https://www.gov.uk/courts-tribunals/the-financial-list
-        selectable: false
-        listable: false
-    -
-        code: EWHC-Chancery-IntellectualProperty
-        name: The Intellectual Property List
-        link: https://www.gov.uk/courts-tribunals/the-intellectual-property-list
-        selectable: false
-        listable: false
-    -
-        code: EWHC-Chancery-Patents
-        name: Patents Court
-        link: https://www.gov.uk/courts-tribunals/patents-court
-        ncn: \[(\d{4})\] (EWHC) (\d+) \((Pat)\)
-        selectable: false
-        listable: false
-    -
-        code: EWHC-Chancery-PropertyTrustsProbate
-        name: The Property, Trusts and Probate List
-        link: https://www.gov.uk/courts-tribunals/the-property-trusts-and-probate-list
-        selectable: false
-        listable: false
-    -
-        code: EWHC-Chancery-Appeals
-        name: Chancery Appeals
-        link: https://www.gov.uk/courts-tribunals/chancery-division-of-the-high-court
-        selectable: false
-        listable: false
+    - code: EWHC-QBD-Admin
+      name: Administrative Court
+      list_name: High Court (Administrative Court)
+      link: https://www.gov.uk/courts-tribunals/administrative-court
+      ncn: \[(\d{4})\] (EWHC) (\d+) \((Admin)\)
+      param: "ewhc/admin"
+      start_year: 2003
+      end_year: 2022
+      selectable: true
+      listable: true
+    - code: EWHC-KBD-Admin
+      name: Administrative Court
+      list_name: High Court (Administrative Court)
+      link: https://www.gov.uk/courts-tribunals/administrative-court
+      ncn: \[(\d{4})\] (EWHC) (\d+) \((Admin)\)
+      param: "ewhc/admin"
+      start_year: 2022
+      end_year: 2022
+      selectable: false
+      listable: false
+    - code: EWHC-QBD-Admiralty
+      name: Admiralty Court
+      list_name: High Court (Admiralty Division)
+      link: https://www.gov.uk/courts-tribunals/admiralty-court
+      ncn: \[(\d{4})\] (EWHC) (\d+) \((Admlty)\)
+      param: "ewhc/admlty"
+      start_year: 2003
+      end_year: 2022
+      selectable: true
+      listable: true
+    - code: EWHC-KBD-Admiralty
+      name: Admiralty Court
+      list_name: High Court (Admiralty Division)
+      link: https://www.gov.uk/courts-tribunals/admiralty-court
+      ncn: \[(\d{4})\] (EWHC) (\d+) \((Admlty)\)
+      param: "ewhc/admlty"
+      start_year: 2022
+      end_year: 2022
+      selectable: false
+      listable: false
+    - code: EWHC-Chancery
+      name: Chancery Division of the High Court
+      list_name: High Court (Chancery Division)
+      link: https://www.gov.uk/courts-tribunals/chancery-division-of-the-high-court
+      ncn: \[(\d{4})\] (EWHC) (\d+) \((Ch)\)
+      param: "ewhc/ch"
+      start_year: 2003
+      end_year: 2022
+      selectable: true
+      listable: true
+    - code: EWHC-QBD-Commercial
+      name: Commercial Court
+      list_name: High Court (Commercial Court)
+      link: https://www.gov.uk/courts-tribunals/commercial-court
+      ncn: \[(\d{4})\] (EWHC) (\d+) \((Comm)\)
+      param: "ewhc/comm"
+      start_year: 2003
+      end_year: 2022
+      selectable: true
+      listable: true
+    - code: EWHC-KBD-Commercial
+      name: Commercial Court
+      list_name: High Court (Commercial Court)
+      link: https://www.gov.uk/courts-tribunals/commercial-court
+      ncn: \[(\d{4})\] (EWHC) (\d+) \((Comm)\)
+      param: "ewhc/comm"
+      start_year: 2022
+      end_year: 2022
+      selectable: false
+      listable: false
+    - code: EWHC-SeniorCourtsCosts
+      name: Senior Courts Costs Office
+      list_name: High Court (Senior Court Costs Office)
+      link: https://www.gov.uk/courts-tribunals/senior-courts-costs-office
+      ncn: \[(\d{4})\] (EWHC) (\d+) \((SCCO)\)
+      param: "ewhc/scco"
+      extra_params: ["ewhc/costs"]
+      start_year: 2003
+      end_year: 2022
+      selectable: true
+      listable: true
+    - code: EWHC-Family
+      name: Family Division of the High Court
+      list_name: High Court (Family Division)
+      link: https://www.gov.uk/courts-tribunals/family-division-of-the-high-court
+      ncn: \[(\d{4})\] (EWHC) (\d+) \((Fam)\)
+      param: "ewhc/fam"
+      start_year: 2003
+      end_year: 2022
+      selectable: true
+      listable: true
+    - code: EWHC-Chancery-IPEC
+      name: Intellectual Property Enterprise Court
+      link: https://www.gov.uk/courts-tribunals/intellectual-property-enterprise-court
+      ncn: \[(\d{4})\] (EWHC) (\d+) \((IPEC)\)
+      param: "ewhc/ipec"
+      start_year: 2003
+      end_year: 2022
+      selectable: true
+      listable: true
+    - code: EWHC-Mercantile
+      name: Mercantile Court
+      list_name: High Court (Mercantile Court)
+      link: https://www.gov.uk/courts-tribunals/intellectual-property-enterprise-court
+      ncn: \[(\d{4})\] (EWHC) (\d+) \((IPEC)\)
+      param: "ewhc/mercantile"
+      start_year: 2008
+      end_year: 2014
+      selectable: true
+      listable: true
+    - code: EWHC-Chancery-Patents
+      name: Patents Court
+      list_name: High Court (Patents Court)
+      link: https://www.gov.uk/courts-tribunals/patents-court
+      ncn: \[(\d{4})\] (EWHC) (\d+) \((Pat)\)
+      param: "ewhc/pat"
+      start_year: 2003
+      end_year: 2022
+      selectable: true
+      listable: true
+    - code: EWHC-KBD
+      name: King's / Queen's Bench Division of the High Court
+      link: https://www.gov.uk/courts-tribunals/kings-bench-division-of-the-high-court
+      ncn: \[(\d{4})\] (EWHC) (\d+) \((KB)\)
+      param: "ewhc/kb"
+      extra_params: ["ewhc/qb"]
+      start_year: 2003
+      end_year: 2022
+      selectable: true
+      listable: false
+    - code: EWHC-QBD
+      name: High Court (Queen's Bench Division)
+      link: https://www.gov.uk/courts-tribunals/queens-bench-division-of-the-high-court
+      ncn: \[(\d{4})\] (EWHC) (\d+) \((QB)\)
+      param: "ewhc/qb"
+      start_year: 2003
+      end_year: 2022
+      selectable: false
+      listable: true
+    - code: EWHC-KBD
+      name: High Court (King's Bench Division)
+      link: https://www.gov.uk/courts-tribunals/kings-bench-division-of-the-high-court
+      ncn: \[(\d{4})\] (EWHC) (\d+) \((KB)\)
+      param: "ewhc/kb"
+      start_year: 2022
+      end_year: 2022
+      selectable: false
+      listable: true
+    - code: EWHC-QBD-TCC
+      name: Technology and Construction Court
+      list_name: High Court (Technology and Construction Court)
+      link: https://www.gov.uk/courts-tribunals/technology-and-construction-court
+      ncn: \[(\d{4})\] (EWHC) (\d+) \((TCC)\)
+      param: "ewhc/tcc"
+      start_year: 2003
+      end_year: 2022
+      selectable: true
+      listable: true
+    - code: EWHC-KBD-TCC
+      name: Technology and Construction Court
+      list_name: High Court (Technology and Construction Court)
+      link: https://www.gov.uk/courts-tribunals/technology-and-construction-court
+      ncn: \[(\d{4})\] (EWHC) (\d+) \((TCC)\)
+      param: "ewhc/tcc"
+      start_year: 2022
+      end_year: 2022
+      selectable: false
+      listable: false
+    - code: EWCOP
+      name: Court of Protection
+      link: https://www.gov.uk/courts-tribunals/court-of-protection
+      ncn: \[(\d{4})\] (EWCOP) (\d+)
+      param: "ewcop"
+      start_year: 2009
+      end_year: 2022
+      selectable: true
+      listable: true
+    - code: EWFC
+      name: Family Court
+      link: https://www.judiciary.uk/you-and-the-judiciary/going-to-court/family-law-courts/
+      ncn: \[(\d{4})\] (EWFC) (\d+)
+      param: "ewfc"
+      start_year: 2009
+      end_year: 2022
+      selectable: true
+      listable: true
+    - code: EWHC-QBD-Planning
+      name: Planning Court
+      link: https://www.gov.uk/courts-tribunals/planning-court
+      selectable: false
+      listable: false
+    - code: EWHC-KBD-Planning
+      name: Planning Court
+      link: https://www.gov.uk/courts-tribunals/planning-court
+      selectable: false
+      listable: false
+    - code: EWHC-QBD-BusinessAndProperty
+      name: The Business and Property Courts
+      link: https://www.gov.uk/courts-tribunals/the-business-and-property-courts
+      selectable: false
+      listable: false
+    - code: EWHC-KBD-BusinessAndProperty
+      name: The Business and Property Courts
+      link: https://www.gov.uk/courts-tribunals/the-business-and-property-courts
+      selectable: false
+      listable: false
+    - code: EWHC-QBD-Commercial-Financial
+      name: The Financial List
+      link: https://www.gov.uk/courts-tribunals/the-financial-list
+      ncn: \[(\d{4})\] (EWHC) (\d+) \((Comm)\)
+      selectable: false
+      listable: false
+    - code: EWHC-KBD-Commercial-Financial
+      name: The Financial List
+      link: https://www.gov.uk/courts-tribunals/the-financial-list
+      ncn: \[(\d{4})\] (EWHC) (\d+) \((Comm)\)
+      selectable: false
+      listable: false
+    - code: EWHC-QBD-Commercial-Circuit
+      name: Circuit Commercial Court
+      link: https://www.gov.uk/courts-tribunals/commercial-circuit-court
+      ncn: \[(\d{4})\] (EWHC) (\d+) \((Comm)\)
+      selectable: false
+      listable: false
+    - code: EWHC-KBD-Commercial-Circuit
+      name: Circuit Commercial Court
+      link: https://www.gov.uk/courts-tribunals/commercial-circuit-court
+      ncn: \[(\d{4})\] (EWHC) (\d+) \((Comm)\)
+      selectable: false
+      listable: false
+    - code: EWHC-Chancery-BusinessAndProperty
+      name: The Business and Property Courts
+      link: https://www.gov.uk/courts-tribunals/the-business-and-property-courts
+      selectable: false
+      listable: false
+    - code: EWHC-Chancery-Business
+      name: The Business List
+      link: https://www.gov.uk/courts-tribunals/the-business-list
+      selectable: false
+      listable: false
+    - code: EWHC-Chancery-InsolvencyAndCompanies
+      name: Insolvency and Companies List
+      link: https://www.gov.uk/courts-tribunals/insolvency-list
+      selectable: false
+      listable: false
+    - code: EWHC-Chancery-Financial
+      name: The Financial List
+      link: https://www.gov.uk/courts-tribunals/the-financial-list
+      selectable: false
+      listable: false
+    - code: EWHC-Chancery-IntellectualProperty
+      name: The Intellectual Property List
+      link: https://www.gov.uk/courts-tribunals/the-intellectual-property-list
+      selectable: false
+      listable: false
+    - code: EWHC-Chancery-Patents
+      name: Patents Court
+      link: https://www.gov.uk/courts-tribunals/patents-court
+      ncn: \[(\d{4})\] (EWHC) (\d+) \((Pat)\)
+      selectable: false
+      listable: false
+    - code: EWHC-Chancery-PropertyTrustsProbate
+      name: The Property, Trusts and Probate List
+      link: https://www.gov.uk/courts-tribunals/the-property-trusts-and-probate-list
+      selectable: false
+      listable: false
+    - code: EWHC-Chancery-Appeals
+      name: Chancery Appeals
+      link: https://www.gov.uk/courts-tribunals/chancery-division-of-the-high-court
+      selectable: false
+      listable: false
 - name: upper_tribunals
   display_name: "Upper Tribunals"
   is_tribunal: true
   courts:
-    -
-        code: UKUT-IAC
-        name: Upper Tribunal Immigration and Asylum Chamber
-        list_name: Upper Tribunal (Immigration and Asylum Chamber)
-        link: https://www.gov.uk/courts-tribunals/upper-tribunal-immigration-and-asylum-chamber
-        ncn: \[(\d{4})\] (UKUT) (\d+) \((IAC)\)
-        selectable: true
-        listable: true
-        param: 'ukut/iac'
-        start_year: 2010
-        end_year: 2022
+    - code: UKUT-IAC
+      name: Upper Tribunal Immigration and Asylum Chamber
+      list_name: Upper Tribunal (Immigration and Asylum Chamber)
+      link: https://www.gov.uk/courts-tribunals/upper-tribunal-immigration-and-asylum-chamber
+      ncn: \[(\d{4})\] (UKUT) (\d+) \((IAC)\)
+      selectable: true
+      listable: true
+      param: "ukut/iac"
+      start_year: 2010
+      end_year: 2022
 
-    -
-        code: UKUT-LC
-        name: Upper Tribunal Lands Chamber
-        list_name: Upper Tribunal (Lands Chamber)
-        link: https://www.gov.uk/courts-tribunals/upper-tribunal-lands-chamber
-        ncn: \[(\d{4})\] (UKUT) (\d+) \((LC)\)
-        selectable: true
-        listable: true
-        param: 'ukut/lc'
-        start_year: 2015
-        end_year: 2022
-    -
-        code: UKUT-TCC
-        name: Upper Tribunal Tax and Chancery Chamber
-        list_name: Upper Tribunal (Tax and Chancery Chamber)
-        link: https://www.gov.uk/courts-tribunals/upper-tribunal-tax-and-chancery-chamber
-        ncn: \[(\d{4})\] (UKUT) (\d+) \((TCC)\)
-        selectable: true
-        listable: true
-        param: 'ukut/tcc'
-        start_year: 2017
-        end_year: 2022
-    -
-        code: UKUT-AAC
-        name: Upper Tribunal Administrative Appeals Chamber
-        list_name: Upper Tribunal (Administrative Appeals Chamber)
-        link: https://www.gov.uk/courts-tribunals/upper-tribunal-administrative-appeals-chamber
-        ncn: \[(\d{4})\] (UKUT) (\d+) \((AAC)\)
-        selectable: true
-        listable: true
-        param: 'ukut/aac'
-        start_year: 2022
-        end_year: 2022
+    - code: UKUT-LC
+      name: Upper Tribunal Lands Chamber
+      list_name: Upper Tribunal (Lands Chamber)
+      link: https://www.gov.uk/courts-tribunals/upper-tribunal-lands-chamber
+      ncn: \[(\d{4})\] (UKUT) (\d+) \((LC)\)
+      selectable: true
+      listable: true
+      param: "ukut/lc"
+      start_year: 2015
+      end_year: 2022
+    - code: UKUT-TCC
+      name: Upper Tribunal Tax and Chancery Chamber
+      list_name: Upper Tribunal (Tax and Chancery Chamber)
+      link: https://www.gov.uk/courts-tribunals/upper-tribunal-tax-and-chancery-chamber
+      ncn: \[(\d{4})\] (UKUT) (\d+) \((TCC)\)
+      selectable: true
+      listable: true
+      param: "ukut/tcc"
+      start_year: 2017
+      end_year: 2022
+    - code: UKUT-AAC
+      name: Upper Tribunal Administrative Appeals Chamber
+      list_name: Upper Tribunal (Administrative Appeals Chamber)
+      link: https://www.gov.uk/courts-tribunals/upper-tribunal-administrative-appeals-chamber
+      ncn: \[(\d{4})\] (UKUT) (\d+) \((AAC)\)
+      selectable: true
+      listable: true
+      param: "ukut/aac"
+      start_year: 2022
+      end_year: 2022
 - name: employment_appeal_tribunal
   display_name: ~
   is_tribunal: true
   courts:
-    -
-        code: EAT
-        name: Employment Appeal Tribunal
-        link: https://www.gov.uk/courts-tribunals/employment-appeal-tribunal
-        ncn: \[(\d{4})\] (EAT) (\d+)
-        selectable: true
-        listable: true
-        param: 'eat'
-        start_year: 2021
-        end_year: 2022
+    - code: EAT
+      name: Employment Appeal Tribunal
+      link: https://www.gov.uk/courts-tribunals/employment-appeal-tribunal
+      ncn: \[(\d{4})\] (EAT) (\d+)
+      selectable: true
+      listable: true
+      param: "eat"
+      start_year: 2021
+      end_year: 2022
 - name: first_tier_tribunals
   display_name: "First-tier Tribunals"
   is_tribunal: true
   courts:
-    -
-        code: UKFTT-TC
-        name: First-tier Tribunal (Tax Chamber)
-        link: https://www.gov.uk/courts-tribunals/first-tier-tribunal-tax
-        ncn: \[(\d{4})\] (UKFTT) (\d+) \((TC)\)
-        param: 'ukftt/tc'
-        start_year: 2022
-        end_year: 2022
-        selectable: true
-        listable: true
-    -
-        code: UKFTT-GRC
-        name: First-tier Tribunal (General Regulatory Chamber)
-        param: 'ukftt/grc'
-        link: https://www.gov.uk/courts-tribunals/first-tier-tribunal-general-regulatory-chamber
-        ncn: \[(\d{4})\] (UKFTT) (\d+) \((GRC)\)
-        start_year: 2022
-        end_year: 2022
-        selectable: true
-        listable: true
-    -
-        code: ET
-        name: Employment Tribunal
-        link: https://www.gov.uk/courts-tribunals/employment-tribunal
-        start_year: 2022
-        end_year: 2022
-        selectable: false
-        listable: false
+    - code: UKFTT-TC
+      name: First-tier Tribunal (Tax Chamber)
+      link: https://www.gov.uk/courts-tribunals/first-tier-tribunal-tax
+      ncn: \[(\d{4})\] (UKFTT) (\d+) \((TC)\)
+      param: "ukftt/tc"
+      start_year: 2022
+      end_year: 2022
+      selectable: true
+      listable: true
+    - code: UKFTT-GRC
+      name: First-tier Tribunal (General Regulatory Chamber)
+      param: "ukftt/grc"
+      link: https://www.gov.uk/courts-tribunals/first-tier-tribunal-general-regulatory-chamber
+      ncn: \[(\d{4})\] (UKFTT) (\d+) \((GRC)\)
+      start_year: 2022
+      end_year: 2022
+      selectable: true
+      listable: true
+    - code: ET
+      name: Employment Tribunal
+      link: https://www.gov.uk/courts-tribunals/employment-tribunal
+      start_year: 2022
+      end_year: 2022
+      selectable: false
+      listable: false

--- a/src/ds_caselaw_utils/data/neutral_citation_regex.yaml
+++ b/src/ds_caselaw_utils/data/neutral_citation_regex.yaml
@@ -4,11 +4,14 @@
 # so the URL becomes eat/2022/1
 
 [
-  ['^\[(\d{4})\] (UKSC|UKPC) (\d+)$',  [2, 1, 3]],
+  ['^\[(\d{4})\] (UKSC|UKPC) (\d+)$', [2, 1, 3]],
   ['^\[(\d{4})\] (EWCA) (Civ|Crim) (\d+)$', [2, 3, 1, 4]],
-  ['^\[(\d{4})\] (EWHC) (\d+) \((Admin|Admlty|Ch|Comm|Costs|Fam|IPEC|Pat|QB|KB|SCCO|TCC)\)$', [2, 4, 1, 3]],
+  [
+    '^\[(\d{4})\] (EWHC) (\d+) \((Admin|Admlty|Ch|Comm|Costs|Fam|IPEC|Pat|QB|KB|SCCO|TCC)\)$',
+    [2, 4, 1, 3],
+  ],
   ['^\[(\d{4})\] (EWFC|EWCOP) (\d+)$', [2, 1, 3]],
   ['^\[(\d{4})\] (UKUT) (\d+) \((AAC|IAC|LC|TCC)\)$', [2, 4, 1, 3]],
   ['^\[(\d{4})\] (EAT) (\d+)$', [2, 1, 3]],
-  ['^\[(\d{4})\] (UKFTT) (\d+) \((TC|GRC)\)$', [2, 4, 1, 3]]
+  ['^\[(\d{4})\] (UKFTT) (\d+) \((TC|GRC)\)$', [2, 4, 1, 3]],
 ]

--- a/src/ds_caselaw_utils/data/schema/courts.schema.json
+++ b/src/ds_caselaw_utils/data/schema/courts.schema.json
@@ -1,0 +1,75 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schema.caselaw.nationalarchives.gov.uk/courts.schema.json",
+  "title": "Courts",
+  "description": "A list of courts",
+  "type": "array",
+  "items": {
+    "type": "object",
+    "properties": {
+      "name": {
+        "type": "string"
+      },
+      "display_name": {
+        "type": ["string", "null"]
+      },
+      "is_tribunal": {
+        "type": "boolean"
+      },
+      "courts": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "code": {
+              "type": "string",
+              "pattern": "^[A-Za-z]{2,}(-[A-Za-z]{2,})*$"
+            },
+            "name": {
+              "type": "string"
+            },
+            "list_name": {
+              "type": "string"
+            },
+            "param": {
+              "type": "string",
+              "pattern": "^[a-z]{2,}(/[a-z]{2,})?$"
+            },
+            "extra_params": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "pattern": "^[a-z]{2,}(/[a-z]{2,})?$"
+              }
+
+            },
+            "ncn": {
+              "type": "string"
+            },
+            "link": {
+              "type": "string",
+              "format": "uri"
+            },
+            "start_year": {
+              "type": "integer",
+              "minimum": 1066
+            },
+            "end_year": {
+              "type": "integer"
+            },
+            "listable": {
+              "type": "boolean"
+            },
+            "selectable": {
+              "type": "boolean"
+            }
+          },
+          "required": ["code", "name", "link", "listable", "selectable"],
+          "additionalProperties": false
+        }
+      }
+    },
+    "required": ["name", "display_name", "is_tribunal", "courts"],
+    "additionalProperties": false
+  }
+}

--- a/src/ds_caselaw_utils/data/schema/courts.schema.json
+++ b/src/ds_caselaw_utils/data/schema/courts.schema.json
@@ -41,7 +41,6 @@
                 "type": "string",
                 "pattern": "^[a-z]{2,}(/[a-z]{2,})?$"
               }
-
             },
             "ncn": {
               "type": "string"


### PR DESCRIPTION
At the moment we don't systematically validate the courts data; we rely entirely on code reviews to catch mistakes, or hope that a downstream test will surface any issues before they reach production.

This introduces a schema for the `court_names.yml` file which describes valid data, and checks it using pre-commit.

As a bonus, since this repository has quite a bit of data, we now run prettier over that data to make sure formatting is clean and consistent both within the files and with similar data elsewhere in the project.