### PR TITLE
Courts display their name in repr contexts

### DIFF
--- a/src/ds_caselaw_utils/courts.py
+++ b/src/ds_caselaw_utils/courts.py
@@ -20,6 +20,9 @@ class Court:
         self.start_year = data.get("start_year")
         self.end_year = data.get("end_year") or date.today().year
 
+    def __repr__(self):
+        return self.name
+
 
 class CourtGroup:
     def __init__(self, name, courts):

--- a/src/ds_caselaw_utils/test_courts.py
+++ b/src/ds_caselaw_utils/test_courts.py
@@ -165,6 +165,11 @@ class TestCourtsRepository(unittest.TestCase):
 
 
 class TestCourt(unittest.TestCase):
+    def test_repr_string(self):
+        court = Court({"name": "court_name"})
+        self.assertEqual("court_name", str(court))
+        self.assertEqual("court_name", repr(court))
+
     def test_list_name_explicit(self):
         court = Court({"list_name": "court_name"})
         self.assertEqual("court_name", court.list_name)


### PR DESCRIPTION
Minor tweak so instead of `<ds_caselaw_utils.courts.Court object at 0x1039f91d0>` it shows the name of the court.