### PR TITLE
Add helper to CourtGroups to determine if they should be displayed

### DIFF
--- a/src/ds_caselaw_utils/courts.py
+++ b/src/ds_caselaw_utils/courts.py
@@ -29,6 +29,10 @@ class CourtGroup:
         self.name = name
         self.courts = courts
 
+    @property
+    def display_heading(self):
+        return self.name is not None
+
 
 class CourtNotFoundException(Exception):
     pass

--- a/src/ds_caselaw_utils/test_courts.py
+++ b/src/ds_caselaw_utils/test_courts.py
@@ -4,7 +4,7 @@ from datetime import date
 
 from ruamel.yaml import YAML
 
-from .courts import Court, CourtNotFoundException, CourtsRepository, courts
+from .courts import Court, CourtGroup, CourtNotFoundException, CourtsRepository, courts
 
 
 class TestCourtsRepository(unittest.TestCase):
@@ -189,6 +189,16 @@ class TestCourt(unittest.TestCase):
     def test_end_year_default(self):
         court = Court({})
         self.assertEqual(date.today().year, court.end_year)
+
+
+class TestCourtGroup(unittest.TestCase):
+    def test_display_heading_when_has_display_name(self):
+        group = CourtGroup("name", [])
+        assert group.display_heading
+
+    def test_dont_display_heading_when_no_display_name(self):
+        group = CourtGroup(None, [])
+        assert not group.display_heading
 
 
 class TestCourts(unittest.TestCase):


### PR DESCRIPTION
Some groups are 'dummy' ones (eg 'supreme court') which only contain a single court, and others should be displayed in the UI as headings (eg 'high court') - this adds a simple property to make this check when rendering the groups in the PUI. Happily 99% of the rest of what we need for the court heirarchy work was already there!