### PR TITLE
Branch/further court heirarchy updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,9 +49,9 @@ The list of courts is defined in `src/ds_caselaw_utils/data/court_names.yml`. Th
         # An internal code for this court:
         code: EWHC-SeniorCourtsCosts
          # The public facing name of the court:
-        name: Senior Courts Costs Office
-        # An alternative wording for use in listings (optional, defaults to `name`)
-        list_name: High Court (Senior Court Costs Office)
+        name: High Court (Senior Courts Costs Office)
+        # An optional alternative wording for use when displayed in grouped format (defaults to 'name'):
+        grouped_name: Senior Court Costs Office
         # A URL to link to for more information on this court:
         link: https://www.gov.uk/courts-tribunals/senior-courts-costs-office
         # A regex matching neutral citations for this court's judgments:

--- a/src/ds_caselaw_utils/courts.py
+++ b/src/ds_caselaw_utils/courts.py
@@ -86,6 +86,32 @@ class CourtsRepository:
                 groups.append(CourtGroup(category.get("display_name"), courts))
         return groups
 
+    def get_grouped_selectable_courts(self):
+        groups = []
+        for category in self._data:
+            if not category.get("is_tribunal"):
+                courts = [
+                    Court(court)
+                    for court in category.get("courts")
+                    if court.get("selectable")
+                ]
+                if len(courts) > 0:
+                    groups.append(CourtGroup(category.get("display_name"), courts))
+        return groups
+
+    def get_grouped_selectable_tribunals(self):
+        groups = []
+        for category in self._data:
+            if category.get("is_tribunal"):
+                courts = [
+                    Court(court)
+                    for court in category.get("courts")
+                    if court.get("selectable")
+                ]
+                if len(courts) > 0:
+                    groups.append(CourtGroup(category.get("display_name"), courts))
+        return groups
+
     def get_listable_groups(self):
         groups = []
         for category in self._data:

--- a/src/ds_caselaw_utils/courts.py
+++ b/src/ds_caselaw_utils/courts.py
@@ -12,7 +12,7 @@ class Court:
     def __init__(self, data):
         self.code = data.get("code")
         self.name = data.get("name")
-        self.list_name = data.get("list_name") or data.get("name")
+        self.grouped_name = data.get("grouped_name") or data.get("name")
         self.link = data.get("link")
         self.ncn = data.get("ncn")
         self.canonical_param = data.get("param")

--- a/src/ds_caselaw_utils/data/court_names.yaml
+++ b/src/ds_caselaw_utils/data/court_names.yaml
@@ -29,8 +29,8 @@
   is_tribunal: false
   courts:
     - code: EWCA-Civil
-      name: Court of Appeal Civil Division
-      list_name: "Court of Appeal (Civil Division)"
+      grouped_name: "Civil Division"
+      name: "Court of Appeal (Civil Division)"
       link: https://www.gov.uk/courts-tribunals/court-of-appeal-civil-division
       ncn: \[(\d{4})\] (EWCA) (Civ) (\d+)
       param: "ewca/civ"
@@ -39,8 +39,8 @@
       selectable: true
       listable: true
     - code: EWCA-Criminal
-      name: Court of Appeal Criminal Division
-      list_name: Court of Appeal (Criminal Division)
+      grouped_name: "Criminal Division"
+      name: Court of Appeal (Criminal Division)
       link: https://www.gov.uk/courts-tribunals/court-of-appeal-criminal-division
       ncn: \[(\d{4})\] (EWCA) (Crim) (\d+)
       param: "ewca/crim"
@@ -49,12 +49,12 @@
       selectable: true
       listable: true
 - name: high_court
-  display_name: "High Court"
+  display_name: "High Court (England & Wales)"
   is_tribunal: false
   courts:
     - code: EWHC-QBD-Admin
-      name: Administrative Court
-      list_name: High Court (Administrative Court)
+      grouped_name: "Administrative Court"
+      name: High Court (Administrative Court)
       link: https://www.gov.uk/courts-tribunals/administrative-court
       ncn: \[(\d{4})\] (EWHC) (\d+) \((Admin)\)
       param: "ewhc/admin"
@@ -63,8 +63,8 @@
       selectable: true
       listable: true
     - code: EWHC-KBD-Admin
-      name: Administrative Court
-      list_name: High Court (Administrative Court)
+      grouped_name: "Administrative Court"
+      name: High Court (Administrative Court)
       link: https://www.gov.uk/courts-tribunals/administrative-court
       ncn: \[(\d{4})\] (EWHC) (\d+) \((Admin)\)
       param: "ewhc/admin"
@@ -73,8 +73,8 @@
       selectable: false
       listable: false
     - code: EWHC-QBD-Admiralty
-      name: Admiralty Court
-      list_name: High Court (Admiralty Division)
+      grouped_name: "Admiralty Court"
+      name: High Court (Admiralty Division)
       link: https://www.gov.uk/courts-tribunals/admiralty-court
       ncn: \[(\d{4})\] (EWHC) (\d+) \((Admlty)\)
       param: "ewhc/admlty"
@@ -83,8 +83,8 @@
       selectable: true
       listable: true
     - code: EWHC-KBD-Admiralty
-      name: Admiralty Court
-      list_name: High Court (Admiralty Division)
+      grouped_name: "Admiralty Court"
+      name: High Court (Admiralty Division)
       link: https://www.gov.uk/courts-tribunals/admiralty-court
       ncn: \[(\d{4})\] (EWHC) (\d+) \((Admlty)\)
       param: "ewhc/admlty"
@@ -92,9 +92,39 @@
       end_year: 2022
       selectable: false
       listable: false
+    - code: EWHC-QBD-BusinessAndProperty
+      grouped_name: Business and Property Courts
+      name: High Court (Business and Property Courts)
+      link: https://www.gov.uk/courts-tribunals/the-business-and-property-courts
+      selectable: false
+      listable: false
+    - code: EWHC-KBD-BusinessAndProperty
+      grouped_name: Business and Property Courts
+      name: High Courts (Business and Property Courts)
+      link: https://www.gov.uk/courts-tribunals/the-business-and-property-courts
+      selectable: false
+      listable: false
+    - code: EWHC-Chancery-BusinessAndProperty
+      grouped_name: Business and Property Courts
+      name: High Court (Business and Property Courts)
+      link: https://www.gov.uk/courts-tribunals/the-business-and-property-courts
+      selectable: false
+      listable: false
+    - code: EWHC-Chancery-Business
+      grouped_name: Business List
+      name: High Court (Business List)
+      link: https://www.gov.uk/courts-tribunals/the-business-list
+      selectable: false
+      listable: false
+    - code: EWHC-Chancery-Appeals
+      name: Chancery Appeals
+      grouped_name: High Court (Chancery Appeals)
+      link: https://www.gov.uk/courts-tribunals/chancery-division-of-the-high-court
+      selectable: false
+      listable: false
     - code: EWHC-Chancery
-      name: Chancery Division of the High Court
-      list_name: High Court (Chancery Division)
+      grouped_name: Chancery Division
+      name: High Court (Chancery Division)
       link: https://www.gov.uk/courts-tribunals/chancery-division-of-the-high-court
       ncn: \[(\d{4})\] (EWHC) (\d+) \((Ch)\)
       param: "ewhc/ch"
@@ -102,9 +132,23 @@
       end_year: 2022
       selectable: true
       listable: true
+    - code: EWHC-QBD-Commercial-Circuit
+      grouped_name: Circuit Commercial Court
+      name: High Court (Circuit Commercial Court)
+      link: https://www.gov.uk/courts-tribunals/commercial-circuit-court
+      ncn: \[(\d{4})\] (EWHC) (\d+) \((Comm)\)
+      selectable: false
+      listable: false
+    - code: EWHC-KBD-Commercial-Circuit
+      grouped_name: Circuit Commercial Court
+      name: High Court (Circuit Commercial Court)
+      link: https://www.gov.uk/courts-tribunals/commercial-circuit-court
+      ncn: \[(\d{4})\] (EWHC) (\d+) \((Comm)\)
+      selectable: false
+      listable: false
     - code: EWHC-QBD-Commercial
-      name: Commercial Court
-      list_name: High Court (Commercial Court)
+      grouped_name: Commercial Court
+      name: High Court (Commercial Court)
       link: https://www.gov.uk/courts-tribunals/commercial-court
       ncn: \[(\d{4})\] (EWHC) (\d+) \((Comm)\)
       param: "ewhc/comm"
@@ -113,8 +157,8 @@
       selectable: true
       listable: true
     - code: EWHC-KBD-Commercial
-      name: Commercial Court
-      list_name: High Court (Commercial Court)
+      grouped_name: Commercial Court
+      name: High Court (Commercial Court)
       link: https://www.gov.uk/courts-tribunals/commercial-court
       ncn: \[(\d{4})\] (EWHC) (\d+) \((Comm)\)
       param: "ewhc/comm"
@@ -123,8 +167,8 @@
       selectable: false
       listable: false
     - code: EWHC-Family
-      name: Family Division of the High Court
-      list_name: High Court (Family Division)
+      grouped_name: Family Division
+      name: High Court (Family Division)
       link: https://www.gov.uk/courts-tribunals/family-division-of-the-high-court
       ncn: \[(\d{4})\] (EWHC) (\d+) \((Fam)\)
       param: "ewhc/fam"
@@ -132,8 +176,51 @@
       end_year: 2022
       selectable: true
       listable: true
+    - code: EWHC-QBD-Commercial-Financial
+      grouped_name: Financial List
+      name: High Court (Financial List)
+      link: https://www.gov.uk/courts-tribunals/the-financial-list
+      ncn: \[(\d{4})\] (EWHC) (\d+) \((Comm)\)
+      selectable: false
+      listable: false
+    - code: EWHC-KBD-Commercial-Financial
+      grouped_name: Financial List
+      name: High Court (Financial List)
+      link: https://www.gov.uk/courts-tribunals/the-financial-list
+      ncn: \[(\d{4})\] (EWHC) (\d+) \((Comm)\)
+      selectable: false
+      listable: false
+    - code: EWHC-Chancery-Financial
+      grouped_name: Financial List
+      name: High Court (Financial List)
+      link: https://www.gov.uk/courts-tribunals/the-financial-list
+      selectable: false
+      listable: false
+    - code: EWHC-Chancery-InsolvencyAndCompanies
+      grouped_name: Insolvency and Companies List
+      name: High Court (Insolvency and Companies List)
+      link: https://www.gov.uk/courts-tribunals/insolvency-list
+      selectable: false
+      listable: false
+    - code: EWHC-Chancery-IPEC
+      grouped_name: Intellectual Property Enterprise Court
+      name: High Court (Intellectual Property Enterprise Court)
+      link: https://www.gov.uk/courts-tribunals/intellectual-property-enterprise-court
+      ncn: \[(\d{4})\] (EWHC) (\d+) \((IPEC)\)
+      param: "ewhc/ipec"
+      start_year: 2003
+      end_year: 2022
+      selectable: true
+      listable: true
+    - code: EWHC-Chancery-IntellectualProperty
+      grouped_name: Intellectual Property List
+      name: High Court (Intellectual Property List)
+      link: https://www.gov.uk/courts-tribunals/the-intellectual-property-list
+      selectable: false
+      listable: false
     - code: EWHC-KBD
-      name: King's / Queen's Bench Division of the High Court
+      grouped_name: King's / Queen's Bench Division
+      name: High Court (King's / Queen's Bench Division)
       link: https://www.gov.uk/courts-tribunals/kings-bench-division-of-the-high-court
       ncn: \[(\d{4})\] (EWHC) (\d+) \((KB)\)
       param: "ewhc/kb"
@@ -142,45 +229,8 @@
       end_year: 2022
       selectable: true
       listable: false
-    - code: EWHC-Chancery-IPEC
-      name: Intellectual Property Enterprise Court
-      link: https://www.gov.uk/courts-tribunals/intellectual-property-enterprise-court
-      ncn: \[(\d{4})\] (EWHC) (\d+) \((IPEC)\)
-      param: "ewhc/ipec"
-      start_year: 2003
-      end_year: 2022
-      selectable: true
-      listable: true
-    - code: EWHC-Mercantile
-      name: Mercantile Court
-      list_name: High Court (Mercantile Court)
-      link: https://www.gov.uk/courts-tribunals/intellectual-property-enterprise-court
-      ncn: \[(\d{4})\] (EWHC) (\d+) \((IPEC)\)
-      param: "ewhc/mercantile"
-      start_year: 2008
-      end_year: 2014
-      selectable: true
-      listable: true
-    - code: EWHC-Chancery-Patents
-      name: Patents Court
-      list_name: High Court (Patents Court)
-      link: https://www.gov.uk/courts-tribunals/patents-court
-      ncn: \[(\d{4})\] (EWHC) (\d+) \((Pat)\)
-      param: "ewhc/pat"
-      start_year: 2003
-      end_year: 2022
-      selectable: true
-      listable: true
-    - code: EWHC-QBD
-      name: High Court (Queen's Bench Division)
-      link: https://www.gov.uk/courts-tribunals/queens-bench-division-of-the-high-court
-      ncn: \[(\d{4})\] (EWHC) (\d+) \((QB)\)
-      param: "ewhc/qb"
-      start_year: 2003
-      end_year: 2022
-      selectable: false
-      listable: true
     - code: EWHC-KBD
+      grouped_name: King's Bench Division
       name: High Court (King's Bench Division)
       link: https://www.gov.uk/courts-tribunals/kings-bench-division-of-the-high-court
       ncn: \[(\d{4})\] (EWHC) (\d+) \((KB)\)
@@ -189,9 +239,64 @@
       end_year: 2022
       selectable: false
       listable: true
+    - code: EWHC-Mercantile
+      grouped_name: Mercantile Court
+      name: High Court (Mercantile Court)
+      link: https://www.gov.uk/courts-tribunals/intellectual-property-enterprise-court
+      ncn: \[(\d{4})\] (EWHC) (\d+) \((IPEC)\)
+      param: "ewhc/mercantile"
+      start_year: 2008
+      end_year: 2014
+      selectable: true
+      listable: true
+    - code: EWHC-Chancery-Patents
+      grouped_name: Patents Court
+      name: High Court (Patents Court)
+      link: https://www.gov.uk/courts-tribunals/patents-court
+      ncn: \[(\d{4})\] (EWHC) (\d+) \((Pat)\)
+      param: "ewhc/pat"
+      start_year: 2003
+      end_year: 2022
+      selectable: true
+      listable: true
+    - code: EWHC-QBD
+      grouped_name: Queen's Bench Division
+      name: High Court (Queen's Bench Division)
+      link: https://www.gov.uk/courts-tribunals/queens-bench-division-of-the-high-court
+      ncn: \[(\d{4})\] (EWHC) (\d+) \((QB)\)
+      param: "ewhc/qb"
+      start_year: 2003
+      end_year: 2022
+      selectable: false
+      listable: true
+    - code: EWHC-Chancery-Patents
+      grouped_name: Patents Court
+      name: High Court (Patents Court)
+      link: https://www.gov.uk/courts-tribunals/patents-court
+      ncn: \[(\d{4})\] (EWHC) (\d+) \((Pat)\)
+      selectable: false
+      listable: false
+    - code: EWHC-QBD-Planning
+      grouped_name: Planning Court
+      name: High Court (Planning Court)
+      link: https://www.gov.uk/courts-tribunals/planning-court
+      selectable: false
+      listable: false
+    - code: EWHC-KBD-Planning
+      grouped_name: Planning Court
+      name: High Court (Planning Court)
+      link: https://www.gov.uk/courts-tribunals/planning-court
+      selectable: false
+      listable: false
+    - code: EWHC-Chancery-PropertyTrustsProbate
+      grouped_name: Property, Trusts and Probate List
+      name: High Court (Property, Trusts and Probate List)
+      link: https://www.gov.uk/courts-tribunals/the-property-trusts-and-probate-list
+      selectable: false
+      listable: false
     - code: EWHC-SeniorCourtsCosts
-      name: Senior Courts Costs Office
-      list_name: High Court (Senior Court Costs Office)
+      grouped_name: Senior Courts Costs Office
+      name: High Court (Senior Court Costs Office)
       link: https://www.gov.uk/courts-tribunals/senior-courts-costs-office
       ncn: \[(\d{4})\] (EWHC) (\d+) \((SCCO)\)
       param: "ewhc/scco"
@@ -201,8 +306,8 @@
       selectable: true
       listable: true
     - code: EWHC-QBD-TCC
-      name: Technology and Construction Court
-      list_name: High Court (Technology and Construction Court)
+      grouped_name: Technology and Construction Court
+      name: High Court (Technology and Construction Court)
       link: https://www.gov.uk/courts-tribunals/technology-and-construction-court
       ncn: \[(\d{4})\] (EWHC) (\d+) \((TCC)\)
       param: "ewhc/tcc"
@@ -211,98 +316,13 @@
       selectable: true
       listable: true
     - code: EWHC-KBD-TCC
-      name: Technology and Construction Court
-      list_name: High Court (Technology and Construction Court)
+      grouped_name: Technology and Construction Court
+      name: High Court (Technology and Construction Court)
       link: https://www.gov.uk/courts-tribunals/technology-and-construction-court
       ncn: \[(\d{4})\] (EWHC) (\d+) \((TCC)\)
       param: "ewhc/tcc"
       start_year: 2022
       end_year: 2022
-      selectable: false
-      listable: false
-    - code: EWHC-QBD-Planning
-      name: Planning Court
-      link: https://www.gov.uk/courts-tribunals/planning-court
-      selectable: false
-      listable: false
-    - code: EWHC-KBD-Planning
-      name: Planning Court
-      link: https://www.gov.uk/courts-tribunals/planning-court
-      selectable: false
-      listable: false
-    - code: EWHC-QBD-BusinessAndProperty
-      name: The Business and Property Courts
-      link: https://www.gov.uk/courts-tribunals/the-business-and-property-courts
-      selectable: false
-      listable: false
-    - code: EWHC-KBD-BusinessAndProperty
-      name: The Business and Property Courts
-      link: https://www.gov.uk/courts-tribunals/the-business-and-property-courts
-      selectable: false
-      listable: false
-    - code: EWHC-QBD-Commercial-Financial
-      name: The Financial List
-      link: https://www.gov.uk/courts-tribunals/the-financial-list
-      ncn: \[(\d{4})\] (EWHC) (\d+) \((Comm)\)
-      selectable: false
-      listable: false
-    - code: EWHC-KBD-Commercial-Financial
-      name: The Financial List
-      link: https://www.gov.uk/courts-tribunals/the-financial-list
-      ncn: \[(\d{4})\] (EWHC) (\d+) \((Comm)\)
-      selectable: false
-      listable: false
-    - code: EWHC-QBD-Commercial-Circuit
-      name: Circuit Commercial Court
-      link: https://www.gov.uk/courts-tribunals/commercial-circuit-court
-      ncn: \[(\d{4})\] (EWHC) (\d+) \((Comm)\)
-      selectable: false
-      listable: false
-    - code: EWHC-KBD-Commercial-Circuit
-      name: Circuit Commercial Court
-      link: https://www.gov.uk/courts-tribunals/commercial-circuit-court
-      ncn: \[(\d{4})\] (EWHC) (\d+) \((Comm)\)
-      selectable: false
-      listable: false
-    - code: EWHC-Chancery-BusinessAndProperty
-      name: The Business and Property Courts
-      link: https://www.gov.uk/courts-tribunals/the-business-and-property-courts
-      selectable: false
-      listable: false
-    - code: EWHC-Chancery-Business
-      name: The Business List
-      link: https://www.gov.uk/courts-tribunals/the-business-list
-      selectable: false
-      listable: false
-    - code: EWHC-Chancery-InsolvencyAndCompanies
-      name: Insolvency and Companies List
-      link: https://www.gov.uk/courts-tribunals/insolvency-list
-      selectable: false
-      listable: false
-    - code: EWHC-Chancery-Financial
-      name: The Financial List
-      link: https://www.gov.uk/courts-tribunals/the-financial-list
-      selectable: false
-      listable: false
-    - code: EWHC-Chancery-IntellectualProperty
-      name: The Intellectual Property List
-      link: https://www.gov.uk/courts-tribunals/the-intellectual-property-list
-      selectable: false
-      listable: false
-    - code: EWHC-Chancery-Patents
-      name: Patents Court
-      link: https://www.gov.uk/courts-tribunals/patents-court
-      ncn: \[(\d{4})\] (EWHC) (\d+) \((Pat)\)
-      selectable: false
-      listable: false
-    - code: EWHC-Chancery-PropertyTrustsProbate
-      name: The Property, Trusts and Probate List
-      link: https://www.gov.uk/courts-tribunals/the-property-trusts-and-probate-list
-      selectable: false
-      listable: false
-    - code: EWHC-Chancery-Appeals
-      name: Chancery Appeals
-      link: https://www.gov.uk/courts-tribunals/chancery-division-of-the-high-court
       selectable: false
       listable: false
 - name: lower_courts
@@ -332,8 +352,8 @@
   is_tribunal: true
   courts:
     - code: UKUT-AAC
-      name: Upper Tribunal Administrative Appeals Chamber
-      list_name: Upper Tribunal (Administrative Appeals Chamber)
+      grouped_name: Administrative Appeals Chamber
+      name: Upper Tribunal (Administrative Appeals Chamber)
       link: https://www.gov.uk/courts-tribunals/upper-tribunal-administrative-appeals-chamber
       ncn: \[(\d{4})\] (UKUT) (\d+) \((AAC)\)
       selectable: true
@@ -341,19 +361,9 @@
       param: "ukut/aac"
       start_year: 2022
       end_year: 2022
-    - code: UKUT-LC
-      name: Upper Tribunal Lands Chamber
-      list_name: Upper Tribunal (Lands Chamber)
-      link: https://www.gov.uk/courts-tribunals/upper-tribunal-lands-chamber
-      ncn: \[(\d{4})\] (UKUT) (\d+) \((LC)\)
-      selectable: true
-      listable: true
-      param: "ukut/lc"
-      start_year: 2015
-      end_year: 2022
     - code: UKUT-IAC
-      name: Upper Tribunal Immigration and Asylum Chamber
-      list_name: Upper Tribunal (Immigration and Asylum Chamber)
+      grouped_name: Immigration and Asylum Chamber
+      name: Upper Tribunal (Immigration and Asylum Chamber)
       link: https://www.gov.uk/courts-tribunals/upper-tribunal-immigration-and-asylum-chamber
       ncn: \[(\d{4})\] (UKUT) (\d+) \((IAC)\)
       selectable: true
@@ -361,9 +371,19 @@
       param: "ukut/iac"
       start_year: 2010
       end_year: 2022
+    - code: UKUT-LC
+      grouped_name: Lands Chamber
+      name: Upper Tribunal (Lands Chamber)
+      link: https://www.gov.uk/courts-tribunals/upper-tribunal-lands-chamber
+      ncn: \[(\d{4})\] (UKUT) (\d+) \((LC)\)
+      selectable: true
+      listable: true
+      param: "ukut/lc"
+      start_year: 2015
+      end_year: 2022
     - code: UKUT-TCC
-      name: Upper Tribunal Tax and Chancery Chamber
-      list_name: Upper Tribunal (Tax and Chancery Chamber)
+      grouped_name: Tax and Chancery Chamber
+      name: Upper Tribunal (Tax and Chancery Chamber)
       link: https://www.gov.uk/courts-tribunals/upper-tribunal-tax-and-chancery-chamber
       ncn: \[(\d{4})\] (UKUT) (\d+) \((TCC)\)
       selectable: true
@@ -389,13 +409,15 @@
   is_tribunal: true
   courts:
     - code: ET
-      name: Employment Tribunal
+      grouped_name: Employment Tribunal
+      name: First-tier Tribunal (Employment Tribunal)
       link: https://www.gov.uk/courts-tribunals/employment-tribunal
       start_year: 2022
       end_year: 2022
       selectable: false
       listable: false
     - code: UKFTT-GRC
+      grouped_name: General Regulatory Chamber
       name: First-tier Tribunal (General Regulatory Chamber)
       param: "ukftt/grc"
       link: https://www.gov.uk/courts-tribunals/first-tier-tribunal-general-regulatory-chamber
@@ -405,6 +427,7 @@
       selectable: true
       listable: true
     - code: UKFTT-TC
+      grouped_name: Tax Chamber
       name: First-tier Tribunal (Tax Chamber)
       link: https://www.gov.uk/courts-tribunals/first-tier-tribunal-tax
       ncn: \[(\d{4})\] (UKFTT) (\d+) \((TC)\)

--- a/src/ds_caselaw_utils/data/schema/courts.schema.json
+++ b/src/ds_caselaw_utils/data/schema/courts.schema.json
@@ -28,7 +28,7 @@
             "name": {
               "type": "string"
             },
-            "list_name": {
+            "grouped_name": {
               "type": "string"
             },
             "param": {

--- a/src/ds_caselaw_utils/test_courts.py
+++ b/src/ds_caselaw_utils/test_courts.py
@@ -182,13 +182,13 @@ class TestCourt(unittest.TestCase):
         self.assertEqual("court_name", str(court))
         self.assertEqual("court_name", repr(court))
 
-    def test_list_name_explicit(self):
-        court = Court({"list_name": "court_name"})
-        self.assertEqual("court_name", court.list_name)
+    def test_grouped_name_explicit(self):
+        court = Court({"grouped_name": "court_name"})
+        self.assertEqual("court_name", court.grouped_name)
 
-    def test_list_name_default(self):
+    def test_grouped_name_default(self):
         court = Court({"name": "court_name"})
-        self.assertEqual("court_name", court.list_name)
+        self.assertEqual("court_name", court.grouped_name)
 
     def test_param_aliases(self):
         court = Court({"param": "param_1", "extra_params": ["param_2"]})

--- a/src/ds_caselaw_utils/test_courts.py
+++ b/src/ds_caselaw_utils/test_courts.py
@@ -175,6 +175,84 @@ class TestCourtsRepository(unittest.TestCase):
             "court3", [c.canonical_param for c in repo.get_listable_tribunals()]
         )
 
+    def test_returns_grouped_selectable_courts(self):
+        data = [
+            {
+                "name": "group2",
+                "display_name": "Court group",
+                "is_tribunal": False,
+                "courts": [
+                    {"param": "court1", "selectable": True, "name": "Selectable court"},
+                    {
+                        "param": "court2",
+                        "selectable": False,
+                        "name": "Unselectable court",
+                    },
+                ],
+            },
+            {
+                "name": "group2",
+                "display_name": "Tribunal group",
+                "is_tribunal": True,
+                "courts": [
+                    {
+                        "param": "court3",
+                        "selectable": True,
+                        "name": "Selectable tribunal",
+                    }
+                ],
+            },
+        ]
+        repo = CourtsRepository(data)
+        groups = repo.get_grouped_selectable_courts()
+        self.assertIn("Court group", [g.name for g in groups])
+        self.assertNotIn("Tribunal group", [g.name for g in groups])
+        self.assertIn("Selectable court", [c.name for g in groups for c in g.courts])
+        self.assertNotIn(
+            "Unselectable court", [c.name for g in groups for c in g.courts]
+        )
+        self.assertNotIn(
+            "Selectable tribunal", [c.name for g in groups for c in g.courts]
+        )
+
+    def test_returns_grouped_selectable_tribunals(self):
+        data = [
+            {
+                "name": "group1",
+                "display_name": "Court group",
+                "is_tribunal": False,
+                "courts": [
+                    {"param": "court1", "selectable": True, "name": "Selectable court"},
+                ],
+            },
+            {
+                "name": "group2",
+                "display_name": "Tribunal group",
+                "is_tribunal": True,
+                "courts": [
+                    {
+                        "param": "court2",
+                        "selectable": True,
+                        "name": "Selectable tribunal",
+                    },
+                    {
+                        "param": "court3",
+                        "selectable": False,
+                        "name": "Unselectable tribunal",
+                    },
+                ],
+            },
+        ]
+        repo = CourtsRepository(data)
+        groups = repo.get_grouped_selectable_tribunals()
+        self.assertIn("Tribunal group", [g.name for g in groups])
+        self.assertNotIn("Court group", [g.name for g in groups])
+        self.assertIn("Selectable tribunal", [c.name for g in groups for c in g.courts])
+        self.assertNotIn(
+            "Unselectable tribunal", [c.name for g in groups for c in g.courts]
+        )
+        self.assertNotIn("Selectable court", [c.name for g in groups for c in g.courts])
+
 
 class TestCourt(unittest.TestCase):
     def test_repr_string(self):


### PR DESCRIPTION
Reorders and renames court heirarchy for consistency, and adds getters for just courts and tribunals returned in the heirarchy.