### PR TITLE
update UKAIT metadata in court_names.yml

### DIFF
--- a/src/ds_caselaw_utils/data/court_names.yaml
+++ b/src/ds_caselaw_utils/data/court_names.yaml
@@ -382,6 +382,7 @@
       selectable: true
       listable: true
       param: "ukut/iac"
+      extra_params: ["ukait"]
       start_year: 2010
       end_year: 2022
     - code: UKUT-LC
@@ -435,4 +436,14 @@
       start_year: 2022
       end_year: 2022
       selectable: true
+      listable: true
+    - code: UKAIT
+      grouped_name: Asylum & Immigration Tribunal
+      name: Asylum & Immigration Tribunal
+      link: https://www.gov.uk/courts-tribunals/upper-tribunal-immigration-and-asylum-chamber
+      ncn: \[(\d{4})\] (UKAIT) (\d+))
+      param: "ukait"
+      start_year: 2003
+      end_year: 2010
+      selectable: false
       listable: true


### PR DESCRIPTION
The Upper Tribunal (Immigation and Asylum Chamber) used to be called the "Asylum and Immigration Tribunal", with a different NCN format (and therefore URL param). This updates the court metadata to treat it the same way as we do with other renamed courts - a single 'select' box for both names which transparently searches both 'courts', and two entries in all lists with the appropriate dates (eg on the about this service page).