### PR TITLE
Don't list old asylum and immigration tribunal

### DIFF
--- a/src/ds_caselaw_utils/data/court_names.yaml
+++ b/src/ds_caselaw_utils/data/court_names.yaml
@@ -383,7 +383,7 @@
       listable: true
       param: "ukut/iac"
       extra_params: ["ukait"]
-      start_year: 2010
+      start_year: 2003
       end_year: 2022
     - code: UKUT-LC
       grouped_name: Lands Chamber
@@ -436,14 +436,4 @@
       start_year: 2022
       end_year: 2022
       selectable: true
-      listable: true
-    - code: UKAIT
-      grouped_name: Asylum & Immigration Tribunal
-      name: Asylum & Immigration Tribunal
-      link: https://www.gov.uk/courts-tribunals/upper-tribunal-immigration-and-asylum-chamber
-      ncn: \[(\d{4})\] (UKAIT) (\d+))
-      param: "ukait"
-      start_year: 2003
-      end_year: 2010
-      selectable: false
       listable: true


### PR DESCRIPTION
A little bit of an oversight in my PR before - we should allow the parameter alias, but not list the two courts seperately in the UI (the same as we do with scco/costs, rather than queens bench / kings bench)