### PR TITLE
Add a UKAIT court to the yaml file

### DIFF
--- a/src/ds_caselaw_utils/data/court_names.yaml
+++ b/src/ds_caselaw_utils/data/court_names.yaml
@@ -385,6 +385,15 @@
       extra_params: ["ukait"]
       start_year: 2003
       end_year: 2022
+    - code: UKAIT
+      selectable: false
+      listable: false
+      param: "ukait"
+      name: Asylum & Immigration Tribunal
+      link: https://www.gov.uk/courts-tribunals/upper-tribunal-immigration-and-asylum-chamber
+      ncn: \[(\d{4})\] (UKAIT) (\d+)
+      start_year: 2003
+      end_year: 2010
     - code: UKUT-LC
       grouped_name: Lands Chamber
       name: Upper Tribunal (Lands Chamber)


### PR DESCRIPTION
The editor UI (via the api client) relies on this to validate that the inputted court code is correct, so UKAIT needs its own section even though it's not ever displayed in the public UI (selectable and listable are both `false`).