### PR TITLE
Add Jurisdiction info to Courts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog 1.0.0].
 
+## [Unreleased]
+
+- Add jurisdiction metadata to courts to support GRC subdivisions
+
 ## [Release 1.3.5]
 
 - Fix an issue with EWFC B's name taking priority for the 'ewfc' param

--- a/src/ds_caselaw_utils/data/court_names.yaml
+++ b/src/ds_caselaw_utils/data/court_names.yaml
@@ -447,6 +447,52 @@
       end_year: 2022
       selectable: true
       listable: true
+      jurisdictions:
+        - code: Charity
+          prefix: CA
+          name: Charity
+        - code: CommunityRightToBid
+          prefix: CR
+          name: Community Right to Bid
+        - code: NetworkInformationSystems
+          prefix: NIS
+          name: Electronic Communications, Postal Services, and Network Information Systems
+        - code: Environment
+          prefix: NV
+          name: Environment
+        - code: EstateAgents
+          prefix: EEA
+          name: Estate Agents
+        - code: ExamBoards
+          prefix: EB
+          name: Exam Boards
+        - code: FoodSafety
+          prefix: FD
+          name: Food Safety
+        - code: Gambling
+          prefix: GA
+          name: Gambling
+        - code: ImmigrationServices
+          prefix: IMS
+          name: Immigration Services
+        - code: IndividualElectoralRegulation
+          prefix: IR
+          name: Individual Electoral Regulation
+        - code: InformationRights
+          prefix: EA
+          name: Information Rights
+        - code: Pensions
+          prefix: PEN
+          name: Pensions
+        - code: StandardsAndLicensing
+          prefix: PR
+          name: Standards & Licensing
+        - code: Transport
+          prefix: D
+          name: Transport
+        - code: WelfareOfAnimals
+          prefix: WA
+          name: Welfare of Animals
     - code: UKFTT-TC
       grouped_name: Tax Chamber
       name: First-tier Tribunal (Tax Chamber)

--- a/src/ds_caselaw_utils/data/schema/courts.schema.json
+++ b/src/ds_caselaw_utils/data/schema/courts.schema.json
@@ -61,6 +61,23 @@
             },
             "selectable": {
               "type": "boolean"
+            },
+            "jurisdictions": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "prefix": {
+                    "type": "string"
+                  },
+                  "name": {
+                    "type": "string"
+                  },
+                  "code": {
+                    "type": "string"
+                  }
+                }
+              }
             }
           },
           "required": ["code", "name", "link", "listable", "selectable"],


### PR DESCRIPTION
The General Regulatory Chamber has a number of _Jurisdictions_ (or 'sub-tribunals' as we sometimes call them). These are different to the separate _Lists_ we see within eg the Chancery Division - _Lists_ are an administrative distinction, decided on by the court themselves, whereas _Jurisdictions_ are a statutory one, decided in law. Neither jurisdiction nor list affects the NCN of the judgment, but they're stored differently in the XML - Lists are represented in the court code in the <uk:court> element, whereas judgments are represented with the <uk:jurisdiction> element in addition to the <uk:court>.

This PR extends the existing court metadata model to include the new Jurisdictions. Courts can contain multiple Jurisdictions with their own code and name, and a Jurisdiction can be looked up in the format "CourtCode/JurisdictionCode".

Jurisdictions inherit all the metadata of their parent court, apart from the code and name, for display in the PUI listing (the same way we currently do with Chncery Division lists).

In addition, a list of all courts and jurisdictions can be returned by passing `with_jurisdictions=True` to `get_all`, for use in the EUI court select autocomplete.