### PR TITLE
fix indexError on getting a non-existent jurisdiction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog 1.0.0].
 
 ## [Unreleased]
 
+- Fix bug where getting a nonexistent jurisdiction for a court raised an IndexError. Now we explicitly raise a CourtNotFoundError for unknown jurisdictions.
+
 ## [Release 1.4.0]
 
 - Add jurisdiction metadata to courts to support GRC subdivisions

--- a/src/ds_caselaw_utils/courts.py
+++ b/src/ds_caselaw_utils/courts.py
@@ -32,7 +32,7 @@ class Court:
         ]
 
     def get_jurisdiction(self, code):
-        return [j for j in self.jurisdictions if j.code == code][0]
+        return next((j for j in self.jurisdictions if j.code == code), None)
 
     def expand_jurisdictions(self):
         return [self] + [
@@ -130,11 +130,12 @@ class CourtsRepository:
 
     def get_court_with_jurisdiction_by_code(self, court_code, jursidiction_code):
         court = self.get_court_by_code(court_code)
-        jurisdiction = court.get_jurisdiction(jursidiction_code)
-        if jurisdiction is not None:
-            return CourtWithJurisdiction(court, jurisdiction)
-        else:
+        if court is None:
             raise CourtNotFoundException()
+        jurisdiction = court.get_jurisdiction(jursidiction_code)
+        if jurisdiction is None:
+            raise CourtNotFoundException()
+        return CourtWithJurisdiction(court, jurisdiction)
 
     def get_by_code(self, code):
         if "/" in code:

--- a/src/ds_caselaw_utils/test_courts.py
+++ b/src/ds_caselaw_utils/test_courts.py
@@ -174,6 +174,29 @@ class TestCourtsRepository(unittest.TestCase):
             "Court 1 – Jurisdiction 1", repo.get_by_code("court1/jurisdiction1").name
         )
 
+    def test_raises_error_for_nonexistent_jurisdictions(self):
+        data = [
+            {
+                "name": "court_group",
+                "courts": [
+                    {
+                        "code": "court1",
+                        "name": "Court 1",
+                        "jurisdictions": [
+                            {"code": "jurisdiction1", "name": "Jurisdiction 1"}
+                        ],
+                    }
+                ],
+            }
+        ]
+        repo = CourtsRepository(data)
+        self.assertRaises(
+            CourtNotFoundException, repo.get_by_code, "court1/jurisdiction2"
+        )
+        self.assertRaises(
+            CourtNotFoundException, repo.get_by_code, "court2/jurisdiction1"
+        )
+
     def test_raises_on_unknown_court_code(self):
         data = [
             {
@@ -353,6 +376,13 @@ class TestCourt(unittest.TestCase):
         )
         jurisdiction = court.get_jurisdiction("jurisdiction1")
         self.assertEqual("Jurisdiction 1", jurisdiction.name)
+
+    def test_get_nonexistent_jurisdiction(self):
+        court = Court(
+            {"jurisdictions": [{"code": "jurisdiction1", "name": "Jurisdiction 1"}]}
+        )
+        jurisdiction = court.get_jurisdiction("jurisdiction2")
+        self.assertIsNone(jurisdiction)
 
     def test_expand_jurisdictions(self):
         court = Court(


### PR DESCRIPTION
Fix bug where getting a nonexistent jurisdiction for a court raised an IndexError. Now we ~~default to returning the parent court~~ explicitly return a CourtNotFoundError for unknown jurisdictions.