### PR TITLE
Remove EWFC-B from list of court names and fold into EWFC.

### DIFF
--- a/src/ds_caselaw_utils/data/court_names.yaml
+++ b/src/ds_caselaw_utils/data/court_names.yaml
@@ -341,22 +341,12 @@
     - code: EWFC
       name: Family Court
       link: https://www.judiciary.uk/you-and-the-judiciary/going-to-court/family-law-courts/
-      ncn: \[(\d{4})\] (EWFC) (\d+)
+      ncn: '\[(\d{4})\] (EWFC) (?:\(B\) )(\d+)'
       param: "ewfc"
       start_year: 2009
       end_year: 2022
       selectable: true
       listable: true
-    - code: "EWFC-B"
-      name: Family Court (B)
-      # This is an artifact of how the Family Court creates tiers of importance.
-      link: https://www.judiciary.uk/you-and-the-judiciary/going-to-court/family-law-courts/
-      ncn: \[(\d{4})\] (EWFC) (B) (\d+)
-      param: "ewfc/b"
-      start_year: 2009
-      end_year: 2022
-      selectable: false
-      listable: false
 
 - name: employment_appeal_tribunal
   display_name: ~


### PR DESCRIPTION
The editor interface had an option for allowing editors to add EWFC-B as a court option. This is incorrect. We in fact want it to appear nowhere, so deleting it from the list of courts appears to be the correct answer.

It's not clear whether other non-listable, non-selectable courts should also be omitted from the list of court names -- currently the editors can select any court. Some of these are historic court names, KB/QB disambiguation etc.

EWFC-B still exists in the list of regular expressions that are NCNs in src/ds_caselaw_utils/data/neutral_citation_regex.yaml .
