### PR TITLE
Pin pypi-publish to v1

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,6 +25,6 @@ jobs:
         run: poetry build
       - name: Publish distribution to PyPI
         if: startsWith(github.ref, 'refs/tags')
-        uses: pypa/gh-action-pypi-publish@master
+        uses: pypa/gh-action-pypi-publish@release/v1.9.0
         with:
           password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
in response to the following error in the logs:

You are using `pypa/gh-action-pypi-publish@master`. The `master` branch of this project has been sunset and will not receive any updates, not even security bug fixes. Please, make sure to use a supported version. If you want to pin to v1 major version, use `pypa/gh-action-pypi-publish@release/v1`. If you feel adventurous, you may opt to use use `pypa/gh-action-pypi-publish@unstable/v1` instead. A more general recommendation is to pin to exact tags or commit SHAs.

Please also consider migrating your setup to use secretless publishing: https://github.com/marketplace/actions/pypi-publish#trusted-publishing