### PR TITLE
[FCL-176] Tooling configuration audit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 dist
+node_modules/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,7 +31,7 @@ repos:
           ]
 
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v3.1.0
+    rev: v4.0.0-alpha.8
     hooks:
       - id: prettier
-        types_or: [yaml, json, markdown]
+        types_or: [yaml, json, xml, markdown, scss, javascript]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,13 +1,18 @@
-exclude: "^docs/|/migrations/"
-default_stages: [commit]
-
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.6.0
     hooks:
-      - id: trailing-whitespace
-      - id: end-of-file-fixer
+      - id: check-added-large-files
+      - id: check-case-conflict
+      - id: check-json
+      - id: check-merge-conflict
+      - id: check-xml
       - id: check-yaml
+      - id: end-of-file-fixer
+      - id: forbid-submodules
+      - id: mixed-line-ending
+      - id: no-commit-to-branch
+      - id: trailing-whitespace
 
   - repo: https://github.com/python-jsonschema/check-jsonschema
     rev: 0.28.6
@@ -42,9 +47,3 @@ repos:
     hooks:
       - id: prettier
         types_or: [yaml, json, markdown]
-
-# sets up .pre-commit-ci.yaml to ensure pre-commit dependencies stay up to date
-ci:
-  autoupdate_schedule: weekly
-  skip: []
-  submodules: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,6 +14,11 @@ repos:
       - id: no-commit-to-branch
       - id: trailing-whitespace
 
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.5.0
+    hooks:
+      - id: ruff-format
+
   - repo: https://github.com/python-jsonschema/check-jsonschema
     rev: 0.28.6
     hooks:
@@ -24,23 +29,6 @@ repos:
             "--schemafile",
             "src/ds_caselaw_utils/data/schema/courts.schema.json",
           ]
-
-  - repo: https://github.com/psf/black
-    rev: 24.4.2
-    hooks:
-      - id: black
-
-  - repo: https://github.com/PyCQA/isort
-    rev: 5.13.2
-    hooks:
-      - id: isort
-
-  - repo: https://github.com/PyCQA/flake8
-    rev: 7.1.0
-    hooks:
-      - id: flake8
-        args: ["--ignore=F401,E501", "--config=setup.cfg"]
-        additional_dependencies: [flake8-isort]
 
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: v3.1.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,30 @@ python = "^3.9"
 
 [tool.poetry.dev-dependencies]
 
+[tool.ruff]
+line-length = 120
+
+[tool.ruff.lint]
+ignore = ["E501", "G004", "PLR2004", "RUF005", "RUF012", "UP040"] # long lines, fstrings in logs, magic values, consider not concat, mutable classbits, type instead of TypeAlias
+extend-select = ["W", "B", "Q", "C90", "I", "UP", "YTT", "ASYNC", "S", "BLE", "A", "COM", "C4", "DTZ", "T10", "DJ", "EM", "EXE", "FA",
+                 "ISC", "ICN", "G", "INP", "PIE", "T20", "PYI", "PT", "Q", "RSE", "RET", "SLF", "SLOT", "SIM", "TID", "TCH", "INT", "PTH",
+                 "FIX", "PGH", "PL", "TRY", "FLY", "PERF", "RUF"]
+unfixable = ["ERA"]
+
+# things skipped:
+# N: naming, possibly good
+# D: docstrings missing throughout
+# ANN: annotations missing throughout
+# FBT: not convinced boolean trap worth auto-banning.
+# CPY: copyright at top of each file
+# G: logging warnings -- fstrings bad?
+# ARG: sometimes you need to accept arguments.
+# TD: somewhat finicky details about formatting TODOs
+# FIX: flags todos: possible to add -- skipped for now
+# ERA: lots of false positives, not a good autofix
+# PD, NPY, AIR: ignored, panda / numpy / airflow specific
+# FURB: not yet out of preview
+
 [build-system]
 requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,26 +1,3 @@
-[flake8]
-max-line-length = 4000
-extend-ignore = E203, E711, E712
-# E203: slices with [long thing : long thing] shouldn't have spaces
-# E712: "is True" not "== True": fails for numpy bools
-# E711: "is None" not "== None": removed out of caution re: E712
-
-exclude = .tox,.git,,docs,venv
-
-[pycodestyle]
-max-line-length = 120
-exclude = .tox,.git,venv
-
-[isort]
-line_length = 88
-known_first_party = ds-caselaw-editor-ui,config
-multi_line_output = 3
-default_section = THIRDPARTY
-skip = venv/
-include_trailing_comma = true
-force_grid_wrap = 0
-use_parentheses = true
-
 [mypy]
 python_version = 3.9
 check_untyped_defs = True

--- a/src/ds_caselaw_utils/courts.py
+++ b/src/ds_caselaw_utils/courts.py
@@ -26,19 +26,13 @@ class Court:
         self.param_aliases = [data.get("param")] + (data.get("extra_params") or [])
         self.start_year = data.get("start_year")
         self.end_year = data.get("end_year") or date.today().year
-        self.jurisdictions = [
-            Jurisdiction(jurisdiction_data)
-            for jurisdiction_data in data.get("jurisdictions", [])
-        ]
+        self.jurisdictions = [Jurisdiction(jurisdiction_data) for jurisdiction_data in data.get("jurisdictions", [])]
 
     def get_jurisdiction(self, code):
         return next((j for j in self.jurisdictions if j.code == code), None)
 
     def expand_jurisdictions(self):
-        return [self] + [
-            CourtWithJurisdiction(self, jurisdiction)
-            for jurisdiction in self.jurisdictions
-        ]
+        return [self] + [CourtWithJurisdiction(self, jurisdiction) for jurisdiction in self.jurisdictions]
 
     def __repr__(self):
         return self.name
@@ -140,16 +134,12 @@ class CourtsRepository:
     def get_by_code(self, code):
         if "/" in code:
             (court_code, jurisdiction_code) = code.split("/")
-            return self.get_court_with_jurisdiction_by_code(
-                court_code, jurisdiction_code
-            )
+            return self.get_court_with_jurisdiction_by_code(court_code, jurisdiction_code)
         else:
             return self.get_court_by_code(code)
 
     def get_all(self, with_jurisdictions=False):
-        courts = [
-            Court(court) for category in self._data for court in category.get("courts")
-        ]
+        courts = [Court(court) for category in self._data for court in category.get("courts")]
         if with_jurisdictions:
             return [c for court in courts for c in court.expand_jurisdictions()]
         else:
@@ -166,11 +156,7 @@ class CourtsRepository:
     def get_selectable_groups(self):
         groups = []
         for category in self._data:
-            courts = [
-                Court(court)
-                for court in category.get("courts")
-                if court.get("selectable")
-            ]
+            courts = [Court(court) for court in category.get("courts") if court.get("selectable")]
             if len(courts) > 0:
                 groups.append(CourtGroup(category.get("display_name"), courts))
         return groups
@@ -179,11 +165,7 @@ class CourtsRepository:
         groups = []
         for category in self._data:
             if not category.get("is_tribunal"):
-                courts = [
-                    Court(court)
-                    for court in category.get("courts")
-                    if court.get("selectable")
-                ]
+                courts = [Court(court) for court in category.get("courts") if court.get("selectable")]
                 if len(courts) > 0:
                     groups.append(CourtGroup(category.get("display_name"), courts))
         return groups
@@ -192,11 +174,7 @@ class CourtsRepository:
         groups = []
         for category in self._data:
             if category.get("is_tribunal"):
-                courts = [
-                    Court(court)
-                    for court in category.get("courts")
-                    if court.get("selectable")
-                ]
+                courts = [Court(court) for court in category.get("courts") if court.get("selectable")]
                 if len(courts) > 0:
                     groups.append(CourtGroup(category.get("display_name"), courts))
         return groups
@@ -204,11 +182,7 @@ class CourtsRepository:
     def get_listable_groups(self):
         groups = []
         for category in self._data:
-            courts = [
-                Court(court)
-                for court in category.get("courts")
-                if court.get("listable")
-            ]
+            courts = [Court(court) for court in category.get("courts") if court.get("listable")]
             if len(courts) > 0:
                 groups.append(CourtGroup(category.get("display_name"), courts))
         return groups

--- a/src/ds_caselaw_utils/test_courts.py
+++ b/src/ds_caselaw_utils/test_courts.py
@@ -30,9 +30,7 @@ class TestCourtsRepository(unittest.TestCase):
             {
                 "name": "court_group",
                 "display_name": "court group 1",
-                "courts": [
-                    {"name": "court1", "jurisdictions": [{"name": "jurisdiction1"}]}
-                ],
+                "courts": [{"name": "court1", "jurisdictions": [{"name": "jurisdiction1"}]}],
             }
         ]
         repo = CourtsRepository(data)
@@ -45,9 +43,7 @@ class TestCourtsRepository(unittest.TestCase):
             {
                 "name": "court_group",
                 "display_name": "court group 1",
-                "courts": [
-                    {"name": "court1", "jurisdictions": [{"name": "jurisdiction1"}]}
-                ],
+                "courts": [{"name": "court1", "jurisdictions": [{"name": "jurisdiction1"}]}],
             }
         ]
         repo = CourtsRepository(data)
@@ -162,17 +158,13 @@ class TestCourtsRepository(unittest.TestCase):
                     {
                         "code": "court1",
                         "name": "Court 1",
-                        "jurisdictions": [
-                            {"code": "jurisdiction1", "name": "Jurisdiction 1"}
-                        ],
+                        "jurisdictions": [{"code": "jurisdiction1", "name": "Jurisdiction 1"}],
                     }
                 ],
             }
         ]
         repo = CourtsRepository(data)
-        self.assertEqual(
-            "Court 1 – Jurisdiction 1", repo.get_by_code("court1/jurisdiction1").name
-        )
+        self.assertEqual("Court 1 – Jurisdiction 1", repo.get_by_code("court1/jurisdiction1").name)
 
     def test_raises_error_for_nonexistent_jurisdictions(self):
         data = [
@@ -182,20 +174,14 @@ class TestCourtsRepository(unittest.TestCase):
                     {
                         "code": "court1",
                         "name": "Court 1",
-                        "jurisdictions": [
-                            {"code": "jurisdiction1", "name": "Jurisdiction 1"}
-                        ],
+                        "jurisdictions": [{"code": "jurisdiction1", "name": "Jurisdiction 1"}],
                     }
                 ],
             }
         ]
         repo = CourtsRepository(data)
-        self.assertRaises(
-            CourtNotFoundException, repo.get_by_code, "court1/jurisdiction2"
-        )
-        self.assertRaises(
-            CourtNotFoundException, repo.get_by_code, "court2/jurisdiction1"
-        )
+        self.assertRaises(CourtNotFoundException, repo.get_by_code, "court1/jurisdiction2")
+        self.assertRaises(CourtNotFoundException, repo.get_by_code, "court2/jurisdiction1")
 
     def test_raises_on_unknown_court_code(self):
         data = [
@@ -229,12 +215,8 @@ class TestCourtsRepository(unittest.TestCase):
         ]
         repo = CourtsRepository(data)
         self.assertIn("court1", [c.canonical_param for c in repo.get_listable_courts()])
-        self.assertNotIn(
-            "court2", [c.canonical_param for c in repo.get_listable_courts()]
-        )
-        self.assertNotIn(
-            "court3", [c.canonical_param for c in repo.get_listable_courts()]
-        )
+        self.assertNotIn("court2", [c.canonical_param for c in repo.get_listable_courts()])
+        self.assertNotIn("court3", [c.canonical_param for c in repo.get_listable_courts()])
 
     def test_returns_listable_tribunals(self):
         data = [
@@ -255,15 +237,9 @@ class TestCourtsRepository(unittest.TestCase):
             },
         ]
         repo = CourtsRepository(data)
-        self.assertNotIn(
-            "court1", [c.canonical_param for c in repo.get_listable_tribunals()]
-        )
-        self.assertNotIn(
-            "court2", [c.canonical_param for c in repo.get_listable_tribunals()]
-        )
-        self.assertIn(
-            "court3", [c.canonical_param for c in repo.get_listable_tribunals()]
-        )
+        self.assertNotIn("court1", [c.canonical_param for c in repo.get_listable_tribunals()])
+        self.assertNotIn("court2", [c.canonical_param for c in repo.get_listable_tribunals()])
+        self.assertIn("court3", [c.canonical_param for c in repo.get_listable_tribunals()])
 
     def test_returns_grouped_selectable_courts(self):
         data = [
@@ -298,12 +274,8 @@ class TestCourtsRepository(unittest.TestCase):
         self.assertIn("Court group", [g.name for g in groups])
         self.assertNotIn("Tribunal group", [g.name for g in groups])
         self.assertIn("Selectable court", [c.name for g in groups for c in g.courts])
-        self.assertNotIn(
-            "Unselectable court", [c.name for g in groups for c in g.courts]
-        )
-        self.assertNotIn(
-            "Selectable tribunal", [c.name for g in groups for c in g.courts]
-        )
+        self.assertNotIn("Unselectable court", [c.name for g in groups for c in g.courts])
+        self.assertNotIn("Selectable tribunal", [c.name for g in groups for c in g.courts])
 
     def test_returns_grouped_selectable_tribunals(self):
         data = [
@@ -338,9 +310,7 @@ class TestCourtsRepository(unittest.TestCase):
         self.assertIn("Tribunal group", [g.name for g in groups])
         self.assertNotIn("Court group", [g.name for g in groups])
         self.assertIn("Selectable tribunal", [c.name for g in groups for c in g.courts])
-        self.assertNotIn(
-            "Unselectable tribunal", [c.name for g in groups for c in g.courts]
-        )
+        self.assertNotIn("Unselectable tribunal", [c.name for g in groups for c in g.courts])
         self.assertNotIn("Selectable court", [c.name for g in groups for c in g.courts])
 
 
@@ -371,16 +341,12 @@ class TestCourt(unittest.TestCase):
         self.assertEqual(date.today().year, court.end_year)
 
     def test_get_jurisdiction(self):
-        court = Court(
-            {"jurisdictions": [{"code": "jurisdiction1", "name": "Jurisdiction 1"}]}
-        )
+        court = Court({"jurisdictions": [{"code": "jurisdiction1", "name": "Jurisdiction 1"}]})
         jurisdiction = court.get_jurisdiction("jurisdiction1")
         self.assertEqual("Jurisdiction 1", jurisdiction.name)
 
     def test_get_nonexistent_jurisdiction(self):
-        court = Court(
-            {"jurisdictions": [{"code": "jurisdiction1", "name": "Jurisdiction 1"}]}
-        )
+        court = Court({"jurisdictions": [{"code": "jurisdiction1", "name": "Jurisdiction 1"}]})
         jurisdiction = court.get_jurisdiction("jurisdiction2")
         self.assertIsNone(jurisdiction)
 


### PR DESCRIPTION
A series of commits which together make all of FCL's repositories behave more consistently with regard to tooling.

## Jira

FCL-176

## What?

- [x] `.pre-commit-config.yaml` does not exclude directories which don't exist, doesn't set default hooks where they aren't needed, and doesn't specify auto-update behaviour
- [x] The `pre-commit-hooks` repo includes the new, broader set of recommended checks
- [x] Python formatting is done using [ruff](https://docs.astral.sh/ruff/)
- [x] `detect-secrets` is removed (deprecated in favour of GitHub's more comprehensive approach)
- [x] prettier config has been harmonised