### PR TITLE
[FCL-134] Use ukiptrib as url, not ukipt

### DIFF
--- a/src/ds_caselaw_utils/data/court_names.yaml
+++ b/src/ds_caselaw_utils/data/court_names.yaml
@@ -388,7 +388,7 @@
       ncn: \[(\d{4})\] (UKIPTrib) (\d+)
       selectable: false
       listable: false
-      param: "ukipt"
+      param: "ukiptrib"
       start_year: 2003
       end_year: 2024
 


### PR DESCRIPTION
The URL of [2022] UKIPTrib 3 is /2022/ukiptrib/3 . 

The public and editor converters are correct:
public/judgments/converters.py
28:    regex = "ewhc|uksc|ukpc|ewca|ewcop|ewfc|ukut|eat|ukftt|ukait|ukiptrib"

editor/judgments/converters.py
28:    regex = "ewhc|uksc|ukpc|ewca|ewcop|ewfc|ukut|eat|ukftt|ukait|ukiptrib"

Bug in https://national-archives.atlassian.net/jira/software/projects/FCL/boards/136?selectedIssue=FCL-134