### PR TITLE
EWCR not EWCRC

### DIFF
--- a/src/ds_caselaw_utils/data/court_names.yaml
+++ b/src/ds_caselaw_utils/data/court_names.yaml
@@ -377,11 +377,11 @@
       end_year: 2022
       selectable: false
       listable: false
-    - code: "EWCRC"
+    - code: "EWCR"
       name: "Crown Court"
       link: https://www.judiciary.uk/courts-and-tribunals/crown-court/
-      ncn: \[(\d{4})\] (EWCRC) (\d+)
-      param: "ewcrc"
+      ncn: \[(\d{4})\] (EWCR) (\d+)
+      param: "ewcr"
       start_year: 2024
       end_year: 2024
       selectable: false

--- a/src/ds_caselaw_utils/data/neutral_citation_regex.yaml
+++ b/src/ds_caselaw_utils/data/neutral_citation_regex.yaml
@@ -10,7 +10,7 @@
     '^\[(\d{4})\] (EWHC) (\d+) \((Admin|Admlty|Ch|Comm|Costs|Fam|IPEC|Pat|QB|KB|SCCO|TCC)\)$',
     [2, 4, 1, 3],
   ],
-  ['^\[(\d{4})\] (EWFC|EWCOP|EWCC|EWCRC) (\d+)$', [2, 1, 3]],
+  ['^\[(\d{4})\] (EWFC|EWCOP|EWCC|EWCR) (\d+)$', [2, 1, 3]],
   ['^\[(\d{4})\] (EWCOP) (\d+) \((T1|T2|T3)\)$', [2, 4, 1, 3]],
   ['^\[(\d{4})\] (UKUT) (\d+) \((AAC|IAC|LC|TCC)\)$', [2, 4, 1, 3]],
   ['^\[(\d{4})\] (EAT) (\d+)$', [2, 1, 3]],

--- a/src/ds_caselaw_utils/test_neutral.py
+++ b/src/ds_caselaw_utils/test_neutral.py
@@ -17,6 +17,8 @@ class TestNeutralURL(unittest.TestCase):
         self.assertEqual(neutral_url("[2023] UKAIT 1"), "/ukait/2023/1")
         self.assertEqual(neutral_url("[2024] EWCOP 17 (T2)"), "/ewcop/t2/2024/17")
         self.assertEqual(neutral_url("[2000] UKIPTrib 99"), "/ukiptrib/2000/99")
+        self.assertEqual(neutral_url("[2000] EWCR 99"), "/ewcr/2000/99")
+        self.assertEqual(neutral_url("[2000] EWCC 99"), "/ewcc/2000/99")
 
     def test_bad_neutral_urls(self):
         self.assertEqual(neutral_url(""), None)
@@ -29,3 +31,4 @@ class TestNeutralURL(unittest.TestCase):
         self.assertEqual(neutral_url("[2022] EAT A"), None)
         self.assertEqual(neutral_url("[2022] NOTACOURT 1 TC"), None)
         self.assertEqual(neutral_url("[2022] EWHC 1 (T2)"), None)
+        self.assertEqual(neutral_url("[2000] EWCRC 99"), None)


### PR DESCRIPTION
https://dxw.slack.com/archives/C04FQ3GFGUQ/p1725269335416609

> Jim's parser change for crown court (Changing EWCRC to EWCR) is going to go through at midday, is is possible to make the other changes (EUI, regex) to change the crown court code today so that the judgment can be published?