### PR TITLE
Add repr to multicourt objects

### DIFF
--- a/src/ds_caselaw_utils/courts.py
+++ b/src/ds_caselaw_utils/courts.py
@@ -120,6 +120,9 @@ class CourtGroup:
         """Is this group displayed in the PUI?"""
         return self.name is not None
 
+    def __repr__(self) -> str:
+        return f"CourtGroup({self.name!r}, {self.courts!r})"
+
 
 class CourtNotFoundException(Exception):
     pass
@@ -136,6 +139,9 @@ class CourtsRepository:
                 if "param" in courtData:
                     self._byParam[CourtParam(courtData["param"])] = court
                 self._byCode[CourtCode(courtData["code"])] = court
+
+    def __repr__(self) -> str:
+        return f"CourtsRepository({self._data!r})"
 
     def get_by_param(self, param: CourtParam) -> Court:
         try:

--- a/src/ds_caselaw_utils/test_courts.py
+++ b/src/ds_caselaw_utils/test_courts.py
@@ -331,6 +331,21 @@ class TestCourtsRepository(unittest.TestCase):
         self.assertNotIn("Unselectable tribunal", [c.name for g in groups for c in g.courts])
         self.assertNotIn("Selectable court", [c.name for g in groups for c in g.courts])
 
+    def test_repr(self):
+        data = [
+            {
+                "name": "group1",
+                "display_name": "Court group",
+                "is_tribunal": False,
+                "courts": [
+                    {"param": "court1", "selectable": True, "name": "Selectable court"},
+                ],
+            }
+        ]
+        valid_data = make_court_repo_valid(data)
+        repo = CourtsRepository(valid_data)
+        assert "'name': 'group1', 'display_name': 'Court group'" in str(repo)
+
 
 class TestCourt(unittest.TestCase):
     def test_repr_string(self):
@@ -477,6 +492,10 @@ class TestCourtGroup(unittest.TestCase):
     def test_dont_display_heading_when_no_display_name(self):
         group = CourtGroup(None, [])
         assert not group.display_heading
+
+    def test_repr(self):
+        group = CourtGroup("name", [])
+        assert str(group) == "CourtGroup('name', [])"
 
 
 class TestCourts(unittest.TestCase):


### PR DESCRIPTION
During debugging, it was annoying that I couldn't see what CourtRepos were.