### PR TITLE
[FCL-194] Add `(high court judges)` to Family Court non-B name

### DIFF
--- a/courts.md
+++ b/courts.md
@@ -70,7 +70,7 @@
 | Court of Protection | EWCOP | ewcop | 2009 | – | ✅ | ✅ |
 | Crown Court | EWCR | ewcr | 2024 | – | ✅ | ✅ |
 | Family Court (B - district and circuit judges) | EWFC-B | ewfc/b | 2009 | – | ❌ | ❌ |
-| Family Court | EWFC | ewfc | 2009 | – | ✅ | ✅ |
+| Family Court (high court judges) | EWFC | ewfc | 2009 | – | ✅ | ✅ |
 
 ## investigatory_powers_tribunal
 

--- a/src/ds_caselaw_utils/data/court_names.yaml
+++ b/src/ds_caselaw_utils/data/court_names.yaml
@@ -320,7 +320,7 @@
       selectable: true
       listable: true
     - code: EWFC
-      name: Family Court
+      name: Family Court (high court judges)
       link: https://www.judiciary.uk/you-and-the-judiciary/going-to-court/family-law-courts/
       ncn_pattern: \[(\d{4})\] (EWFC) (\d+)
       param: "ewfc"


### PR DESCRIPTION
https://national-archives.atlassian.net/jira/software/projects/FCL/boards/136/backlog?selectedIssue=FCL-194

... this doesn't actually help, because in the search we only show non-B but because ewfc is a substring of ewfc-b we get all results, so this could be misleading.