### PR TITLE
[FCL-800] Make court params obligatory where courts are selectable or listable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+### Fix
+
+- make params obligatory where courts are selectable or listable
+
 ## v2.4.0 (2025-03-31)
 
 ### Feat

--- a/courts.md
+++ b/courts.md
@@ -106,4 +106,4 @@
 
 | Name | Code | Param | Start | End | List? | Searchable? |
 | ---- | ---- | ----- | ----- | --- | ----- | ----------- |
-| Immigration Services Tribunal | UKIST | – | 2001 | 2010 | ❌ | ✅ |
+| Immigration Services Tribunal | UKIST | ukist | 2001 | 2010 | ❌ | ✅ |

--- a/src/ds_caselaw_utils/data/court_names.yaml
+++ b/src/ds_caselaw_utils/data/court_names.yaml
@@ -525,6 +525,7 @@
   courts:
     - code: UKIST
       name: Immigration Services Tribunal
+      param: ukist
       link: https://webarchive.nationalarchives.gov.uk/ukgwa/https://immigrationservices.decisions.tribunals.gov.uk/Aspx/default.aspx
       start_year: 2001
       end_year: 2010

--- a/src/ds_caselaw_utils/data/schema/courts.schema.json
+++ b/src/ds_caselaw_utils/data/schema/courts.schema.json
@@ -88,7 +88,17 @@
             }
           },
           "required": ["code", "name", "link", "listable", "selectable"],
-          "additionalProperties": false
+          "additionalProperties": false,
+          "allOf": [
+            {
+              "if": { "properties": { "selectable": { "const": true } } },
+              "then": { "required": ["param"] }
+            },
+            {
+              "if": { "properties": { "listable": { "const": true } } },
+              "then": { "required": ["param"] }
+            }
+          ]
         }
       }
     },

--- a/src/ds_caselaw_utils/types/courts_schema_autogen.py
+++ b/src/ds_caselaw_utils/types/courts_schema_autogen.py
@@ -6,7 +6,25 @@ from typing_extensions import Required
 
 
 class RawCourt(TypedDict, total=False):
-    """ Raw Court. """
+    """
+    Raw Court.
+
+    allOf:
+      - if:
+          properties:
+            selectable:
+              const: true
+        then:
+          required:
+          - param
+      - if:
+          properties:
+            listable:
+              const: true
+        then:
+          required:
+          - param
+    """
 
     code: Required[str]
     """


### PR DESCRIPTION
This introduces a new constraint on the schema, where `param` must be present if either `listable` or `selectable` are true.

## Jira

FCL-800