### PR TITLE
Release v2.4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,15 @@
 
 All notable changes to this project will be documented in this file.
 
-## v2.4.2 (2025-04-22)
+## v2.4.3 (2025-04-23)
 
 ### Fix
 
 - Mercantile court has wrong NCN pattern
+
+## v2.4.2 (2025-04-22)
+
+No changes in this version.
 
 ## v2.4.1 (2025-04-22)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ds_caselaw_utils"
-version = "2.4.2"
+version = "2.4.3"
 description = "Utilities for the National Archives Caselaw project"
 authors = ["Nick Jackson <nick@dxw.com>", "David McKee <dragon@dxw.com>", "Tim Cowlishaw <tim@timcowlishaw.co.uk>", "Laura Porter <laura@dxw.com>"]
 license = "MIT"


### PR DESCRIPTION
This includes the changes we should have included in v2.4.2, namely a fix for mercantile court having an incorrect NCN pattern.