### PR TITLE
FCL-656 | update high court naming to replace & with and

### DIFF
--- a/courts.md
+++ b/courts.md
@@ -22,7 +22,7 @@
 | Civil Division | EWCA-Civil | ewca/civ | 2003 | – | ✅ | ✅ |
 | Criminal Division | EWCA-Criminal | ewca/crim | 2003 | – | ✅ | ✅ |
 
-## High Court (England & Wales) (high_court)
+## High Court (England and Wales) (high_court)
 
 | Name | Code | Param | Start | End | List? | Searchable? |
 | ---- | ---- | ----- | ----- | --- | ----- | ----------- |

--- a/src/ds_caselaw_utils/data/court_names.yaml
+++ b/src/ds_caselaw_utils/data/court_names.yaml
@@ -45,7 +45,7 @@
       selectable: true
       listable: true
 - name: high_court
-  display_name: "High Court (England & Wales)"
+  display_name: "High Court (England and Wales)"
   is_tribunal: false
   courts:
     - code: EWHC-QBD-Admin


### PR DESCRIPTION
Replace the `&` with `and` in the High Court (England and Wales) court name