### PR TITLE
FCL-709 | allow court descriptions to have context passed in

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,12 +80,17 @@ The environment you develop this repo in requires the following to be installed:
 
 - Run `pre-commit install` inside the root directory of the repo to install the git hooks defined in `.pre-commit-config.yaml`.
 
-## Testing
-
 ```bash
 $ poetry shell
-$ cd src/ds_caselaw_utils
-$ python -m unittest
+$ poetry install
+```
+
+## Testing
+
+While in a poetry shell:
+
+```bash
+$ poetry run pytest
 ```
 
 ## Building

--- a/courts.md
+++ b/courts.md
@@ -7,19 +7,19 @@
 
 | Name | Code | Param | Start | End | List? | Searchable? |
 | ---- | ---- | ----- | ----- | --- | ----- | ----------- |
-| United Kingdom Supreme Court | UKSC | uksc | 2014 | – | ✅ | ✅ |
+| United Kingdom Supreme Court | UKSC | uksc | 2009 | – | ✅ | ✅ |
 
 ## privy_council
 
 | Name | Code | Param | Start | End | List? | Searchable? |
 | ---- | ---- | ----- | ----- | --- | ----- | ----------- |
-| Privy Council | UKPC | ukpc | 2014 | – | ✅ | ✅ |
+| Privy Council | UKPC | ukpc | 2009 | – | ✅ | ✅ |
 
 ## Court of Appeal (court_of_appeal)
 
 | Name | Code | Param | Start | End | List? | Searchable? |
 | ---- | ---- | ----- | ----- | --- | ----- | ----------- |
-| Civil Division | EWCA-Civil | ewca/civ | 2003 | – | ✅ | ✅ |
+| Civil Division | EWCA-Civil | ewca/civ | 2001 | – | ✅ | ✅ |
 | Criminal Division | EWCA-Criminal | ewca/crim | 2003 | – | ✅ | ✅ |
 
 ## High Court (England and Wales) (high_court)
@@ -45,7 +45,7 @@
 | Financial List | EWHC-QBD-Commercial-Financial | – | – | – | ❌ | ❌ |
 | High Court (Chancery Appeals) | EWHC-Chancery-Appeals | – | – | – | ❌ | ❌ |
 | Insolvency and Companies List | EWHC-Chancery-InsolvencyAndCompanies | – | – | – | ❌ | ❌ |
-| Intellectual Property Enterprise Court | EWHC-Chancery-IPEC | ewhc/ipec | 2003 | – | ✅ | ✅ |
+| Intellectual Property Enterprise Court | EWHC-Chancery-IPEC | ewhc/ipec | 2013 | – | ✅ | ✅ |
 | Intellectual Property List | EWHC-Chancery-IntellectualProperty | – | – | – | ❌ | ❌ |
 | King's / Queen's Bench Division | EWHC-KBD | ewhc/kb | 2003 | – | ❌ | ✅ |
 | King's Bench Division | EWHC-KBD | ewhc/kb | 2022 | – | ✅ | ❌ |
@@ -56,27 +56,27 @@
 | Property, Trusts and Probate List | EWHC-Chancery-PropertyTrustsProbate | – | – | – | ❌ | ❌ |
 | Queen's Bench Division | EWHC-QBD | ewhc/qb | 2003 | 2022 | ✅ | ❌ |
 | Senior Courts Costs Office | EWHC-SeniorCourtsCosts | ewhc/scco | 2003 | – | ✅ | ✅ |
-| Technology and Construction Court | EWHC-KBD-TCC | ewhc/tcc | 2022 | – | ❌ | ❌ |
+| Technology and Construction Court | EWHC-KBD-TCC | ewhc/tcc | 2003 | – | ❌ | ❌ |
 | Technology and Construction Court | EWHC-QBD-TCC | ewhc/tcc | 2003 | – | ✅ | ✅ |
 
 ## Other Courts (lower_courts)
 
 | Name | Code | Param | Start | End | List? | Searchable? |
 | ---- | ---- | ----- | ----- | --- | ----- | ----------- |
-| County Court | EWCC | ewcc | 2024 | – | ✅ | ✅ |
+| County Court | EWCC | ewcc | 2019 | – | ✅ | ✅ |
 | Court of Protection (Tier 1 - district judges) | EWCOP-T1 | ewcop/t1 | 2009 | – | ❌ | ❌ |
 | Court of Protection (Tier 2 - circuit judges) | EWCOP-T2 | ewcop/t2 | 2009 | – | ❌ | ❌ |
 | Court of Protection (Tier 3 - high court judges) | EWCOP-T3 | ewcop/t3 | 2009 | – | ❌ | ❌ |
 | Court of Protection | EWCOP | ewcop | 2009 | – | ✅ | ✅ |
-| Crown Court | EWCR | ewcr | 2024 | – | ✅ | ✅ |
+| Crown Court | EWCR | ewcr | 2020 | – | ✅ | ✅ |
 | Family Court (B - district and circuit judges) | EWFC-B | ewfc/b | 2009 | – | ❌ | ❌ |
-| Family Court | EWFC | ewfc | 2009 | – | ✅ | ✅ |
+| Family Court | EWFC | ewfc | 2014 | – | ✅ | ✅ |
 
 ## investigatory_powers_tribunal
 
 | Name | Code | Param | Start | End | List? | Searchable? |
 | ---- | ---- | ----- | ----- | --- | ----- | ----------- |
-| Investigatory Powers Tribunal | UKIPT | ukiptrib | 2024 | – | ✅ | ✅ |
+| Investigatory Powers Tribunal | UKIPT | ukiptrib | 2023 | – | ✅ | ✅ |
 
 ## employment_appeal_tribunal
 
@@ -88,19 +88,19 @@
 
 | Name | Code | Param | Start | End | List? | Searchable? |
 | ---- | ---- | ----- | ----- | --- | ----- | ----------- |
-| Administrative Appeals Chamber | UKUT-AAC | ukut/aac | 2022 | – | ✅ | ✅ |
+| Administrative Appeals Chamber | UKUT-AAC | ukut/aac | 2011 | – | ✅ | ✅ |
 | Asylum & Immigration Tribunal | UKAIT | ukait | 2003 | 2010 | ❌ | ❌ |
-| Immigration and Asylum Chamber | UKUT-IAC | ukut/iac | 2003 | – | ✅ | ✅ |
-| Lands Chamber | UKUT-LC | ukut/lc | 2015 | – | ✅ | ✅ |
-| Tax and Chancery Chamber | UKUT-TCC | ukut/tcc | 2017 | – | ✅ | ✅ |
+| Immigration and Asylum Chamber | UKUT-IAC | ukut/iac | 2007 | – | ✅ | ✅ |
+| Lands Chamber | UKUT-LC | ukut/lc | 2014 | – | ✅ | ✅ |
+| Tax and Chancery Chamber | UKUT-TCC | ukut/tcc | 2016 | – | ✅ | ✅ |
 
 ## First-tier Tribunals (first_tier_tribunals)
 
 | Name | Code | Param | Start | End | List? | Searchable? |
 | ---- | ---- | ----- | ----- | --- | ----- | ----------- |
 | Employment Tribunal | ET | – | 2022 | – | ❌ | ❌ |
-| General Regulatory Chamber | UKFTT-GRC | ukftt/grc | 2022 | – | ✅ | ✅ |
-| Tax Chamber | UKFTT-TC | ukftt/tc | 2022 | – | ✅ | ✅ |
+| General Regulatory Chamber | UKFTT-GRC | ukftt/grc | 2019 | – | ✅ | ✅ |
+| Tax Chamber | UKFTT-TC | ukftt/tc | 2019 | – | ✅ | ✅ |
 
 ## Historic Tribunals (historic_tribunals)
 

--- a/src/ds_caselaw_utils/courts.py
+++ b/src/ds_caselaw_utils/courts.py
@@ -80,7 +80,11 @@ class Court:
         description_md_file_path = pathlib.Path(__file__).parent / f"data/markdown/{type}/{filename}.md"
         try:
             with open(description_md_file_path) as file:
-                return str(md.render(file.read()))
+                context = {"name": self.name, "start_year": self.start_year, "end_year": self.end_year}
+
+                template = file.read()
+                template = template.format(**context)
+                return str(md.render(template))
         except FileNotFoundError:
             return None
 

--- a/src/ds_caselaw_utils/data/court_names.yaml
+++ b/src/ds_caselaw_utils/data/court_names.yaml
@@ -7,7 +7,7 @@
       link: https://www.supremecourt.uk/
       ncn_pattern: \[(\d{4})\] (UKSC) (\d+)
       param: "uksc"
-      start_year: 2014
+      start_year: 2009
       selectable: true
       listable: true
 - name: privy_council
@@ -19,7 +19,7 @@
       link: https://www.jcpc.uk/
       ncn_pattern: \[(\d{4})\] (UKPC) (\d+)
       param: "ukpc"
-      start_year: 2014
+      start_year: 2009
       selectable: true
       listable: true
 - name: court_of_appeal
@@ -32,7 +32,7 @@
       link: https://www.gov.uk/courts-tribunals/court-of-appeal-civil-division
       ncn_pattern: \[(\d{4})\] (EWCA) (Civ) (\d+)
       param: "ewca/civ"
-      start_year: 2003
+      start_year: 2001
       selectable: true
       listable: true
     - code: EWCA-Criminal
@@ -196,7 +196,7 @@
       link: https://www.gov.uk/courts-tribunals/intellectual-property-enterprise-court
       ncn_pattern: \[(\d{4})\] (EWHC) (\d+) \((IPEC)\)
       param: "ewhc/ipec"
-      start_year: 2003
+      start_year: 2013
       selectable: true
       listable: true
     - code: EWHC-Chancery-IntellectualProperty
@@ -296,7 +296,7 @@
       link: https://www.gov.uk/courts-tribunals/technology-and-construction-court
       ncn_pattern: \[(\d{4})\] (EWHC) (\d+) \((TCC)\)
       param: "ewhc/tcc"
-      start_year: 2022
+      start_year: 2003
       selectable: false
       listable: false
 - name: lower_courts
@@ -308,7 +308,7 @@
       link: https://www.judiciary.uk/courts-and-tribunals/crown-court/
       ncn_pattern: \[(\d{4})\] (EWCR) (\d+)
       param: "ewcr"
-      start_year: 2024
+      start_year: 2020
       selectable: true
       listable: true
     - code: "EWCC"
@@ -316,7 +316,7 @@
       link: https://www.judiciary.uk/courts-and-tribunals/county-court/
       ncn_pattern: \[(\d{4})\] (EWCC) (\d+)
       param: "ewcc"
-      start_year: 2024
+      start_year: 2019
       selectable: true
       listable: true
     - code: EWFC
@@ -324,7 +324,7 @@
       link: https://www.judiciary.uk/you-and-the-judiciary/going-to-court/family-law-courts/
       ncn_pattern: \[(\d{4})\] (EWFC) (\d+)
       param: "ewfc"
-      start_year: 2009
+      start_year: 2014
       selectable: true
       listable: true
     - code: "EWFC-B"
@@ -380,7 +380,7 @@
       selectable: true
       listable: true
       param: "ukiptrib"
-      start_year: 2024
+      start_year: 2023
 
 - name: employment_appeal_tribunal
   display_name: ~
@@ -406,7 +406,7 @@
       selectable: true
       listable: true
       param: "ukut/aac"
-      start_year: 2022
+      start_year: 2011
     - code: UKUT-IAC
       grouped_name: Immigration and Asylum Chamber
       name: Upper Tribunal (Immigration and Asylum Chamber)
@@ -416,7 +416,7 @@
       listable: true
       param: "ukut/iac"
       extra_params: ["ukait"]
-      start_year: 2003
+      start_year: 2007
     - code: UKAIT
       selectable: false
       listable: false
@@ -434,7 +434,7 @@
       selectable: true
       listable: true
       param: "ukut/lc"
-      start_year: 2015
+      start_year: 2014
     - code: UKUT-TCC
       grouped_name: Tax and Chancery Chamber
       name: Upper Tribunal (Tax and Chancery Chamber)
@@ -443,7 +443,7 @@
       selectable: true
       listable: true
       param: "ukut/tcc"
-      start_year: 2017
+      start_year: 2016
 - name: first_tier_tribunals
   display_name: "First-tier Tribunals"
   is_tribunal: true
@@ -461,7 +461,7 @@
       param: "ukftt/grc"
       link: https://www.gov.uk/courts-tribunals/first-tier-tribunal-general-regulatory-chamber
       ncn_pattern: \[(\d{4})\] (UKFTT) (\d+) \((GRC)\)
-      start_year: 2022
+      start_year: 2019
       selectable: true
       listable: true
       jurisdictions:
@@ -516,7 +516,7 @@
       link: https://www.gov.uk/courts-tribunals/first-tier-tribunal-tax
       ncn_pattern: \[(\d{4})\] (UKFTT) (\d+) \((TC)\)
       param: "ukftt/tc"
-      start_year: 2022
+      start_year: 2019
       selectable: true
       listable: true
 - name: historic_tribunals

--- a/src/ds_caselaw_utils/data/markdown/description/eat.md
+++ b/src/ds_caselaw_utils/data/markdown/description/eat.md
@@ -1,5 +1,5 @@
 This tribunal is responsible for handling appeals against decisions made by the Employment Tribunal where a legal mistake may have been made in the case. They also hear appeals and applications about decisions made by the certification officer and the Central Arbitration Committee.
 
-This tribunal began to regularly transfer decisions to The National Archives in 2022. The oldest decision from this tribunal included in Find Case Law is from 2021.
+This tribunal began to regularly transfer decisions to The National Archives in 2022. The oldest decision from this tribunal included in Find Case Law is from {start_year}.
 
 You can read more about it on the [Employment Appeal tribunal page](https://www.gov.uk/courts-tribunals/employment-appeal-tribunal){target="\_blank"} on the [HM Courts and Tribunals Service website](https://www.gov.uk/government/organisations/hm-courts-and-tribunals-service/about){target="\_blank"}.

--- a/src/ds_caselaw_utils/data/markdown/description/ewca_civ.md
+++ b/src/ds_caselaw_utils/data/markdown/description/ewca_civ.md
@@ -1,5 +1,5 @@
 The Court of Appeal Civil Division is the second most senior court for non-criminal cases in England and Wales.
 
-This court began to regularly transfer judgments to The National Archives in 2022. The oldest judgment from this court included in Find Case Law is from 2001.
+This court began to regularly transfer judgments to The National Archives in 2022. The oldest judgment from this court included in Find Case Law is from {start_year}.
 
 You can read more about it on the [Court of Appeal Civil Division page](https://www.gov.uk/courts-tribunals/court-of-appeal-civil-division){target="\_blank"} on the [HM Courts and Tribunals Service website](https://www.gov.uk/government/organisations/hm-courts-and-tribunals-service/about){target="\_blank"}.

--- a/src/ds_caselaw_utils/data/markdown/description/ewca_crim.md
+++ b/src/ds_caselaw_utils/data/markdown/description/ewca_crim.md
@@ -1,5 +1,5 @@
 The Court of Appeal Criminal Division is the second most senior court for criminal cases in England and Wales.
 
-This court began to regularly transfer judgments to The National Archives in 2022. The oldest judgment from this court included in Find Case Law is from 2003.
+This court began to regularly transfer judgments to The National Archives in 2022. The oldest judgment from this court included in Find Case Law is from {start_year}.
 
 You can read more about it on the [Court of Appeal Criminal Division page](https://www.gov.uk/courts-tribunals/court-of-appeal-criminal-division){target="\_blank"} on the [HM Courts and Tribunals Service website](https://www.gov.uk/government/organisations/hm-courts-and-tribunals-service/about){target="\_blank"}.

--- a/src/ds_caselaw_utils/data/markdown/description/ewcc.md
+++ b/src/ds_caselaw_utils/data/markdown/description/ewcc.md
@@ -2,6 +2,6 @@ The County Court deals with civil (non-criminal) matters.
 
 Unlike criminal cases, in which the state prosecutes an individual, civil court cases arise where an individual or a business believes their rights have been infringed.
 
-This court began to occasionally transfer select judgments to The National Archives in 2024. The oldest judgment from this court included in Find Case Law is from 2024.
+This court began to occasionally transfer select judgments to The National Archives in 2024. The oldest judgment from this court included in Find Case Law is from {start_year}.
 
 You can read more about it on the [County Court page](https://www.gov.uk/courts-tribunals/court-of-protection){target="\_blank"} on the [HM Courts and Tribunals Service website](https://www.judiciary.uk/){target="\_blank"}.

--- a/src/ds_caselaw_utils/data/markdown/description/ewcop.md
+++ b/src/ds_caselaw_utils/data/markdown/description/ewcop.md
@@ -1,5 +1,5 @@
 The Court of Protection makes decisions on financial or welfare matters for people who can’t make decisions at the time they need to be made (they ‘lack mental capacity’).
 
-This court began to regularly transfer judgments to The National Archives in 2022. The oldest judgment from this court included in Find Case Law is from 2009.
+This court began to regularly transfer judgments to The National Archives in 2022. The oldest judgment from this court included in Find Case Law is from {start_year}.
 
 You can read more about it on the [Court of Protection page](https://www.gov.uk/courts-tribunals/court-of-protection){target="\_blank"} on the [HM Courts and Tribunals Service website](https://www.gov.uk/government/organisations/hm-courts-and-tribunals-service/about){target="\_blank"}.

--- a/src/ds_caselaw_utils/data/markdown/description/ewcr.md
+++ b/src/ds_caselaw_utils/data/markdown/description/ewcr.md
@@ -1,5 +1,5 @@
 The Crown Court deals with the most serious criminal offences. It is located in over 70 court centres across England and Wales, including the Central Criminal Court, more commonly known as the Old Bailey.
 
-This court began to occasionally transfer selected judgments to The National Archives in 2024. The oldest judgment from this court included in Find Case Law is from 2024.
+This court began to occasionally transfer selected judgments to The National Archives in 2024. The oldest judgment from this court included in Find Case Law is from {start_year}.
 
 You can read more about this court on the [Crown Court page](https://www.judiciary.uk/courts-and-tribunals/crown-court/){target="\_blank"} on the [HM Courts and Tribunals Service website](https://www.judiciary.uk/){target="\_blank"}.

--- a/src/ds_caselaw_utils/data/markdown/description/ewfc.md
+++ b/src/ds_caselaw_utils/data/markdown/description/ewfc.md
@@ -1,5 +1,5 @@
 Most family cases are heard in the Family Court. A limited number of cases are heard in the Family Division of the High Court, for example cases involving international child abduction and cases involving the inherent jurisdiction of the High Court. You can learn more about when the [family court publish judgments in their practice guidance (opens as PDF)](https://www.judiciary.uk/wp-content/uploads/2014/01/transparency-in-the-family-courts-jan-2014-1.pdf){target="\_blank"}.
 
-This court began to regularly transfer judgments to The National Archives in 2022. The oldest judgment from this court included in Find Case Law is from 2014.
+This court began to regularly transfer judgments to The National Archives in 2022. The oldest judgment from this court included in Find Case Law is from {start_year}.
 
 You can read more about it on the [Family Justice System](https://www.judiciary.uk/courts-and-tribunals/family-law-courts/){target="\_blank"} page on the [HM Courts and Tribunals Service website](https://www.gov.uk/government/organisations/hm-courts-and-tribunals-service/about){target="\_blank"}.

--- a/src/ds_caselaw_utils/data/markdown/description/ewhc_admin.md
+++ b/src/ds_caselaw_utils/data/markdown/description/ewhc_admin.md
@@ -1,5 +1,5 @@
 The Administrative Court is a specialist court within the King’s Bench Division of the High Court. It specialises in public law, often reviewing the decisions made by local authorities and regulatory bodies in England and Wales. The Administrative Court contains a dedicated Planning Court for planning related disputes. Cases in the Administrative Court may be heard by a Divisional Court, which is a court consisting of at least two judges.
 
-This court began to regularly transfer judgments to The National Archives in 2022. The oldest judgment from this court included in Find Case Law is from 2003.
+This court began to regularly transfer judgments to The National Archives in 2022. The oldest judgment from this court included in Find Case Law is from {start_year}.
 
 You can read more about [the Administrative court on the judiciary website](https://www.judiciary.uk/courts-and-tribunals/high-court/administrative-court/){target="\_blank"}.

--- a/src/ds_caselaw_utils/data/markdown/description/ewhc_admlty.md
+++ b/src/ds_caselaw_utils/data/markdown/description/ewhc_admlty.md
@@ -1,5 +1,5 @@
 The Admiralty Court is a specialist court within the King's Bench Division of the High Court. It specialises in shipping and maritime disputes and has the power to arrest and sell ships in England and Wales.
 
-This court began to regularly transfer judgments to The National Archives in 2022. The oldest judgment from this court included in Find Case Law is from 2003.
+This court began to regularly transfer judgments to The National Archives in 2022. The oldest judgment from this court included in Find Case Law is from {start_year}.
 
 You can read more about [the Admiralty court on the judiciary website](https://www.judiciary.uk/courts-and-tribunals/business-and-property-courts/admiralty-court/){target="\_blank"}.

--- a/src/ds_caselaw_utils/data/markdown/description/ewhc_ch.md
+++ b/src/ds_caselaw_utils/data/markdown/description/ewhc_ch.md
@@ -1,5 +1,5 @@
 The Chancery Division is one of three divisions of the High Court. It handles a wide range of civil cases including business disputes, intellectual property and probate issues. It has various lists that deal with specialist issues such as the Business List, Insolvency and Companies List, Intellectual Property List, or Property, Trusts and Probate List. It contains the Intellectual Property Enterprise and Patents Courts.
 
-This court began to regularly transfer judgments to The National Archives in 2022. The oldest judgment from this court included in Find Case Law is from 2003.
+This court began to regularly transfer judgments to The National Archives in 2022. The oldest judgment from this court included in Find Case Law is from {start_year}.
 
 You can read more about it on [the chancery division on the Judiciary website](https://www.judiciary.uk/courts-and-tribunals/business-and-property-courts/chancery-division/){target="\_blank"}.

--- a/src/ds_caselaw_utils/data/markdown/description/ewhc_comm.md
+++ b/src/ds_caselaw_utils/data/markdown/description/ewhc_comm.md
@@ -2,6 +2,6 @@ The Commercial Court is a specialist court within the King’s Bench Division of
 
 The Circuit Commercial Court (previously known as the Mercantile Court) is closely associated with the Commercial Court. It is also part of the broader business and property courts of the High Court of Justice but it deals with smaller, less complex business disputes. It operates in district registries across England and Wales where cases are heard by specialist senior circuit judges. [You can find cases decided by the Mercantile Court here](https://caselaw.nationalarchives.gov.uk/judgments/search?query=&from_day=&from_month=&from_year=&to_day=&to_month=&to_year=&court=ewhc%2Fmercantile&party=&judge=){target="\_blank"}.
 
-This court began to regularly transfer judgments to The National Archives in 2022. The oldest judgment from this court included in Find Case Law is from 2003.
+This court began to regularly transfer judgments to The National Archives in 2022. The oldest judgment from this court included in Find Case Law is from {start_year}.
 
 You can read more about [the Commercial Court on the Judiciary website](https://www.judiciary.uk/courts-and-tribunals/business-and-property-courts/commercial-court/){target="\_blank"}.

--- a/src/ds_caselaw_utils/data/markdown/description/ewhc_fam.md
+++ b/src/ds_caselaw_utils/data/markdown/description/ewhc_fam.md
@@ -2,6 +2,6 @@ The Family Division is one of three divisions of the High Court. It handles comp
 
 The Family Court is different to the Family Division of the High Court. The Family Court is not part of the High Court and hears less complex cases. You can read more about the Family Division of [the High Court and the Family Court on the Judiciary website](https://www.judiciary.uk/courts-and-tribunals/family-law-courts/){target="\_blank"}.
 
-This court began to regularly transfer judgments to The National Archives in 2022. The oldest judgment from this court included in Find Case Law is from 2003.
+This court began to regularly transfer judgments to The National Archives in 2022. The oldest judgment from this court included in Find Case Law is from {start_year}.
 
 You can read more about the Family Division of [the High Court on HM Courts and Tribunals website](https://www.gov.uk/courts-tribunals/family-division-of-the-high-court){target="\_blank"}.

--- a/src/ds_caselaw_utils/data/markdown/description/ewhc_ipec.md
+++ b/src/ds_caselaw_utils/data/markdown/description/ewhc_ipec.md
@@ -1,5 +1,5 @@
 This court is a specialist court within the Chancery Division of the High Court. It is also one of the Business and Property Courts. It handles intellectual property disputes including patents, trademarks, designs and copyright for cases seeking damages for under £500,000. Disputes over £500,000 are handled by the Patents court or the Chancery Division of the High Court.
 
-This court began to regularly transfer judgments to The National Archives in 2022. The oldest judgment from this court included in Find Case Law is from 2013.
+This court began to regularly transfer judgments to The National Archives in 2022. The oldest judgment from this court included in Find Case Law is from {start_year}.
 
 You can read more about [the Intellectual Property Enterprise Court on the Judiciary website](https://www.judiciary.uk/courts-and-tribunals/business-and-property-courts/business-list-general-chancery/intellectual-property-list/intellectual-property-enterprise-court-ipec/){target="\_blank"}.

--- a/src/ds_caselaw_utils/data/markdown/description/ewhc_kb.md
+++ b/src/ds_caselaw_utils/data/markdown/description/ewhc_kb.md
@@ -1,5 +1,5 @@
 The King’s Bench Division is one of three Divisions of the High Court. It handles a wide range of civil claims across contract disputes and civil wrongs (tort) including claims of: negligence, defamation, assault, trespass. This Division contains specialist courts including Administrative, Admiralty, Commercial, and Technology and Construction Courts.
 
-This court began to regularly transfer judgments to The National Archives in 2022. The oldest judgment from this court included in Find Case Law is from 2003.
+This court began to regularly transfer judgments to The National Archives in 2022. The oldest judgment from this court included in Find Case Law is from {start_year}.
 
 You can read more about it on [the King’s Bench Division on the judiciary website](https://www.judiciary.uk/courts-and-tribunals/kings-bench-division/){target="\_blank"}.

--- a/src/ds_caselaw_utils/data/markdown/description/ewhc_pat.md
+++ b/src/ds_caselaw_utils/data/markdown/description/ewhc_pat.md
@@ -1,5 +1,5 @@
 This court is a specialist court within the Chancery Division of the High Court. It is also one of the Business and Property Courts. It specialises in cases involving patents, registered designs and plant varieties. Typically it handles cases where damages sought are over £500,000. Cases less than £500,000 are typically handled by the Intellectual Property Enterprise Court.
 
-This court began to regularly transfer judgments to The National Archives in 2022. The oldest judgment from this court included in Find Case Law is from 2003.
+This court began to regularly transfer judgments to The National Archives in 2022. The oldest judgment from this court included in Find Case Law is from {start_year}.
 
 You can read more about [the Patents Court on the Judiciary website](https://www.judiciary.uk/courts-and-tribunals/business-and-property-courts/business-list-general-chancery/intellectual-property-list/patents-court/){target="\_blank"}.

--- a/src/ds_caselaw_utils/data/markdown/description/ewhc_scco.md
+++ b/src/ds_caselaw_utils/data/markdown/description/ewhc_scco.md
@@ -1,5 +1,5 @@
 This court is part of the High Court. It assesses costs of civil litigation from various courts and tribunals including Court of Appeal, the High Court Chancery, Family and King’s Bench divisions, Court of Protection, and the County Court in London. It also handles disputes relating to solicitors’ charges.
 
-This court began to regularly transfer judgments to The National Archives in 2022. The oldest judgment from this court included in Find Case Law is from 2003.
+This court began to regularly transfer judgments to The National Archives in 2022. The oldest judgment from this court included in Find Case Law is from {start_year}.
 
 You can read more about [the Senior Courts Costs Office on the Judiciary website](https://www.judiciary.uk/courts-and-tribunals/high-court/the-senior-courts-costs-office/){target="\_blank"}.

--- a/src/ds_caselaw_utils/data/markdown/description/ewhc_tcc.md
+++ b/src/ds_caselaw_utils/data/markdown/description/ewhc_tcc.md
@@ -1,5 +1,5 @@
 The Technology and Construction Court is a specialist court within the King’s Bench Division of the High court. It is also one of the Business and Property Courts. It specialises in disputes relating to buildings, engineering and technology. It hears cases involving contract disputes, professional negligence, insurance disputes, procurement and more. It typically handles cases over £250,000.
 
-This court began to regularly transfer judgments to The National Archives in 2022. The oldest judgment from this court included in Find Case Law is from 2003.
+This court began to regularly transfer judgments to The National Archives in 2022. The oldest judgment from this court included in Find Case Law is from {start_year}.
 
 You can read more about it on the link on the [HM Courts and Tribunals Service website](https://www.gov.uk/government/organisations/hm-courts-and-tribunals-service/about){target="\_blank"}.

--- a/src/ds_caselaw_utils/data/markdown/description/ukftt_grc.md
+++ b/src/ds_caselaw_utils/data/markdown/description/ukftt_grc.md
@@ -1,5 +1,5 @@
 The General Regulatory Chamber handles appeals against decisions made by various government regulatory bodies. These appeals cover a range of sectors including charities, community rights, environment, electronic communications, postal services, estate agents, exam boards, food safety, gambling, immigration services, information rights, pensions regulation and more.
 
-This tribunal began to regularly transfer decisions to The National Archives in 2022. The oldest decision from this tribunal included in Find Case Law is from 2019.
+This tribunal began to regularly transfer decisions to The National Archives in 2022. The oldest decision from this tribunal included in Find Case Law is from {start_year}.
 
 You can read more about the General Regulatory Chamber on the [HM Courts and Tribunals website](https://www.gov.uk/courts-tribunals/first-tier-tribunal-general-regulatory-chamber){target="\_blank"}.

--- a/src/ds_caselaw_utils/data/markdown/description/ukftt_tc.md
+++ b/src/ds_caselaw_utils/data/markdown/description/ukftt_tc.md
@@ -2,6 +2,6 @@ The Tax Chamber is responsible for handling appeals against some decisions made 
 
 They also handle some appeals relating to goods seized by either HM Revenue and Customs or Border Force and against some decisions made by the National Crime Agency and the Gambling Commission.
 
-This tribunal began to regularly transfer decisions to The National Archives in 2022. The oldest decision from this tribunal included in Find Case Law is from 2019.
+This tribunal began to regularly transfer decisions to The National Archives in 2022. The oldest decision from this tribunal included in Find Case Law is from {start_year}.
 
 You can read more about it on the Tax Chamber page on the [HM Courts and Tribunals Service website](https://www.gov.uk/courts-tribunals/first-tier-tribunal-tax){target="\_blank"}.

--- a/src/ds_caselaw_utils/data/markdown/description/ukiptrib.md
+++ b/src/ds_caselaw_utils/data/markdown/description/ukiptrib.md
@@ -1,5 +1,5 @@
 The Investigatory Powers Tribunal is an independent court that considers complaints under the Regulation of Investigatory Powers Act 2000 and claims under the Human Rights Act 1998. It considers allegations of unlawful intrusion by public bodies, including the UK intelligence services, the Police and local authorities and investigates alleged conduct by or on behalf of the UK intelligence services whether or not it involves investigatory powers.
 
-This tribunal began to regularly transfer judgments to The National Archives in 2024. The oldest decision from this tribunal included in Find Case Law is from 2024.
+This tribunal began to regularly transfer judgments to The National Archives in 2024. The oldest decision from this tribunal included in Find Case Law is from {start_year}.
 
 You can read more about this tribunal on [the Investigatory Powers Tribunal website](https://investigatorypowerstribunal.org.uk/about-the-tribunal/){target="\_blank"}.

--- a/src/ds_caselaw_utils/data/markdown/description/ukpc.md
+++ b/src/ds_caselaw_utils/data/markdown/description/ukpc.md
@@ -1,5 +1,5 @@
 The Judicial Committee of the Privy Council is the highest court of appeal for many countries in the Commonwealth, UK territories and military sovereign base areas. It also deals with appeals from ecclesiastical courts.
 
-This court began to regularly transfer judgments to The National Archives in 2022. The oldest judgment from this court included in Find Case Law is from 2009.
+This court began to regularly transfer judgments to The National Archives in 2022. The oldest judgment from this court included in Find Case Law is from {start_year}.
 
 You can read more about it on the [Judicial Committee of the Privy Council website](https://www.jcpc.uk/about/role-of-the-jcpc.html){target="\_blank"}.

--- a/src/ds_caselaw_utils/data/markdown/description/uksc.md
+++ b/src/ds_caselaw_utils/data/markdown/description/uksc.md
@@ -1,5 +1,5 @@
 The Supreme Court is the final court of appeal for civil cases in all of the UK and for criminal cases in England, Wales and Northern Ireland. Typically this court deals with important legal questions that affect the public or the constitution.
 
-The UK Supreme Court was established in October 2009. This court began to regularly transfer judgments to The National Archives in 2022. The oldest judgment from this court included in Find Case Law is from 2011. House of Lords decisions from before 2009 are held by the Parliamentary Archives.
+The UK Supreme Court was established in October 2009. This court began to regularly transfer judgments to The National Archives in 2022. The oldest judgment from this court included in Find Case Law is from {start_year}. House of Lords decisions from before 2009 are held by the Parliamentary Archives.
 
 You can read more about it on the [UK Supreme Court website](https://www.supremecourt.uk/){target="\_blank"}.

--- a/src/ds_caselaw_utils/data/markdown/description/ukut_aac.md
+++ b/src/ds_caselaw_utils/data/markdown/description/ukut_aac.md
@@ -2,6 +2,6 @@ The Administrative Appeals Chamber is responsible for dealing with appeals again
 
 They also handle applications for judicial review of decisions made by First-Tier Tribunal (Criminal Injuries Compensation) and other first-tier tribunals where there is no right of appeal.
 
-This tribunal began to regularly transfer decisions to The National Archives in 2022. The oldest decision from this tribunal included in Find Case Law is from 2004.
+This tribunal began to regularly transfer decisions to The National Archives in 2022. The oldest decision from this tribunal included in Find Case Law is from {start_year}.
 
 You can read more about it on the Administrative Appeals Chamber on the [HM Courts and Tribunals Service website](https://www.gov.uk/courts-tribunals/upper-tribunal-administrative-appeals-chamber){target="\_blank"}.

--- a/src/ds_caselaw_utils/data/markdown/description/ukut_iac.md
+++ b/src/ds_caselaw_utils/data/markdown/description/ukut_iac.md
@@ -2,6 +2,6 @@ The Immigration and Asylum Chamber is responsible for handling appeals against s
 
 They also handle applications for immigration bail from people being held by the Home Office on immigration matters.
 
-This tribunal began to regularly transfer decisions to The National Archives in 2022. The oldest decision from this court included in Find Case Law is from 2003.
+This tribunal began to regularly transfer decisions to The National Archives in 2022. The oldest decision from this court included in Find Case Law is from {start_year}.
 
 You can read more about it on the Immigration and Asylum Chamber on the [HM Courts and Tribunals Service website](https://www.gov.uk/courts-tribunals/upper-tribunal-immigration-and-asylum-chamber){target="\_blank"}.

--- a/src/ds_caselaw_utils/data/markdown/description/ukut_lc.md
+++ b/src/ds_caselaw_utils/data/markdown/description/ukut_lc.md
@@ -2,6 +2,6 @@ The Lands Chamber is responsible for handling appeals against decisions made by 
 
 They are also responsible for handling applications for cases about a decision about rates made by the Valuation Tribunal in England or Wales; compensation for the compulsory purchase of land; discharge or modification of land affected by a ‘restrictive covenant’; compensation for the effect on land affected by public works; a tree preservation order; compensation for damage to land damaged by subsidence from mining; the valuation of land or buildings for Capital Gains Tax or Inheritance Tax purposes; a ‘right to light’ dispute; compensation for blighted land and Electronic Communication Code - disputes involving masts and other telecommunications equipment on land.
 
-This tribunal began to regularly transfer decisions to The National Archives in 2022. The oldest decision from this tribunal included in Find Case Law is from 2015.
+This tribunal began to regularly transfer decisions to The National Archives in 2022. The oldest decision from this tribunal included in Find Case Law is from {start_year}.
 
 You can read more about it on the Lands Chamber on the [HM Courts and Tribunals Service website](https://www.gov.uk/courts-tribunals/upper-tribunal-lands-chamber){target="\_blank"}.

--- a/src/ds_caselaw_utils/data/markdown/description/ukut_tcc.md
+++ b/src/ds_caselaw_utils/data/markdown/description/ukut_tcc.md
@@ -2,6 +2,6 @@ The Tax and Chancery Chamber is responsible for handling appeals for certain dec
 
 They also handle appeals against certain decisions made by the Financial Conduct Authority; the Prudential Regulation Authority; Secretary of State for International Trade or the Trade Remedies Authority; the Pensions Regulator; the Bank of England; HM Treasury and Ofgem.
 
-This tribunal began to regularly transfer decisions to The National Archives in 2022. The oldest decision from this tribunal included in Find Case Law is from 2017.
+This tribunal began to regularly transfer decisions to The National Archives in 2022. The oldest decision from this tribunal included in Find Case Law is from {start_year}.
 
 You can read more about it on the Tax and Chancery Chamber page of [HM Courts and Tribunals Service website](https://www.gov.uk/courts-tribunals/upper-tribunal-tax-and-chancery-chamber){target="\_blank"}.

--- a/src/ds_caselaw_utils/test_courts.py
+++ b/src/ds_caselaw_utils/test_courts.py
@@ -457,7 +457,7 @@ class TestCourt(unittest.TestCase):
     def test_render_markdown_text_if_file(self):
         court = CourtFactory({"param": "test"})
         with patch("pathlib.Path.is_file", True), patch("builtins.open", mock_open(read_data="**Test** description.")):
-            assert court._render_markdown_text("test") == "<p><strong>Test</strong> description.</p>\n"
+            assert court.render_markdown_text("test") == "<p><strong>Test</strong> description.</p>\n"
 
     def test_render_markdown_text_with_context(self):
         court = CourtFactory({"param": "test", "name": "test name", "start_year": 2000, "end_year": 2025})
@@ -471,11 +471,11 @@ class TestCourt(unittest.TestCase):
             ),
         ):
             assert (
-                court._render_markdown_text("test")
+                court.render_markdown_text("test")
                 == "<p><strong>Test</strong> description.</p>\n<ul>\n<li>Name: test name</li>\n<li>Start year: 2000</li>\n<li>End year: 2025</li>\n</ul>\n"
             )
 
-    @patch("ds_caselaw_utils.courts.Court._render_markdown_text")
+    @patch("ds_caselaw_utils.courts.Court.render_markdown_text")
     def test_description_text_as_html(self, mock_render):
         court = CourtFactory({"param": "test"})
         mock_render.return_value = "<p>Description.</p>"
@@ -483,7 +483,7 @@ class TestCourt(unittest.TestCase):
         assert court.description_text_as_html == "<p>Description.</p>"
         mock_render.assert_called_once_with("description")
 
-    @patch("ds_caselaw_utils.courts.Court._render_markdown_text")
+    @patch("ds_caselaw_utils.courts.Court.render_markdown_text")
     def test_historic_documents_support_text_as_html(self, mock_render):
         court = CourtFactory({"param": "test"})
         mock_render.return_value = "<p>Support text.</p>"

--- a/src/ds_caselaw_utils/test_courts.py
+++ b/src/ds_caselaw_utils/test_courts.py
@@ -459,6 +459,22 @@ class TestCourt(unittest.TestCase):
         with patch("pathlib.Path.is_file", True), patch("builtins.open", mock_open(read_data="**Test** description.")):
             assert court._render_markdown_text("test") == "<p><strong>Test</strong> description.</p>\n"
 
+    def test_render_markdown_text_with_context(self):
+        court = CourtFactory({"param": "test", "name": "test name", "start_year": 2000, "end_year": 2025})
+        with (
+            patch("pathlib.Path.is_file", True),
+            patch(
+                "builtins.open",
+                mock_open(
+                    read_data="**Test** description.\n - Name: {name}\n - Start year: {start_year}\n - End year: {end_year}"
+                ),
+            ),
+        ):
+            assert (
+                court._render_markdown_text("test")
+                == "<p><strong>Test</strong> description.</p>\n<ul>\n<li>Name: test name</li>\n<li>Start year: 2000</li>\n<li>End year: 2025</li>\n</ul>\n"
+            )
+
     @patch("ds_caselaw_utils.courts.Court._render_markdown_text")
     def test_description_text_as_html(self, mock_render):
         court = CourtFactory({"param": "test"})


### PR DESCRIPTION
This includes the following:

 - Updates the `README.md` with how to run tests/get setup
 - Adds `{start_year}` to the relevant court descriptions 
 - Replaces `{start_year}` with the start_year value in the court yaml data
 - Updates the start_year values in the court data to match those currently generated by `CourtDates` in the PUI
 - Made the render_markdown_text optionally take context to be provided from outside

Next steps:

 - Look into setting the court start_date value on the Court at runtime when fetched from `CourtDates` in the PUI
 - If this is not feasible, pass the `start_year` value in when rendering the text.