### PR TITLE
FCL-709 | handle formatted markdown with {target='blank'} etc

### DIFF
--- a/src/ds_caselaw_utils/courts.py
+++ b/src/ds_caselaw_utils/courts.py
@@ -26,6 +26,11 @@ from .types import CourtCode, CourtParam, JurisdictionCode, NeutralCitationPatte
 md = MarkdownIt("commonmark", {"breaks": True, "html": True}).use(attrs_plugin)
 
 
+class FormatMapDict(dict[str, Any]):
+    def __missing__(self, key: str) -> str:
+        return "{" + key + "}"
+
+
 class InstitutionType(Enum):
     COURT = "court"
     TRIBUNAL = "tribunal"
@@ -84,7 +89,7 @@ class Court:
                 template_context = {**default_context, **context}
 
                 template = file.read()
-                template = template.format(**template_context)
+                template = template.format_map(FormatMapDict(template_context))
                 return str(md.render(template))
         except FileNotFoundError:
             return None

--- a/src/ds_caselaw_utils/test_courts.py
+++ b/src/ds_caselaw_utils/test_courts.py
@@ -466,13 +466,13 @@ class TestCourt(unittest.TestCase):
             patch(
                 "builtins.open",
                 mock_open(
-                    read_data="**Test** description.\n - Name: {name}\n - Start year: {start_year}\n - End year: {end_year}"
+                    read_data="**Test** description.\n - Name: {name}\n - Start year: {start_year}\n - End year: {end_year}\n - Do not replace: {do_not_replace}"
                 ),
             ),
         ):
             assert (
                 court.render_markdown_text("test")
-                == "<p><strong>Test</strong> description.</p>\n<ul>\n<li>Name: test name</li>\n<li>Start year: 2000</li>\n<li>End year: 2025</li>\n</ul>\n"
+                == "<p><strong>Test</strong> description.</p>\n<ul>\n<li>Name: test name</li>\n<li>Start year: 2000</li>\n<li>End year: 2025</li>\n<li>Do not replace: {do_not_replace}</li>\n</ul>\n"
             )
 
     @patch("ds_caselaw_utils.courts.Court.render_markdown_text")


### PR DESCRIPTION
When a description had something that looks like a key to replace, it complained. This allows markdown to continue having things like `{target='blank'}` and we won't try to replace it.