### PR TITLE
Release v2.4.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## v2.4.6 (2025-05-15)
+
+### Fix
+
+- Handle markdown with {target='blank'} when formatting
+
 ## v2.4.5 (2025-05-15)
 
 ### Feat

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ds_caselaw_utils"
-version = "2.4.5"
+version = "2.4.6"
 description = "Utilities for the National Archives Caselaw project"
 authors = ["Nick Jackson <nick@dxw.com>", "David McKee <dragon@dxw.com>", "Tim Cowlishaw <tim@timcowlishaw.co.uk>", "Laura Porter <laura@dxw.com>"]
 license = "MIT"


### PR DESCRIPTION
Release including the following:

- Handle markdown with {target='blank'} when formatting 
