### PR TITLE
Add converter regex for use in editor/public ui

### DIFF
--- a/src/ds_caselaw_utils/courts.py
+++ b/src/ds_caselaw_utils/courts.py
@@ -4,6 +4,7 @@
 Get metadata for the courts covered by the service
 """
 
+import itertools
 import pathlib
 from datetime import date
 from enum import Enum
@@ -310,6 +311,16 @@ class CourtsRepository:
                     if court["listable"]:
                         courts.append(Court(court, InstitutionType.TRIBUNAL))
         return courts
+
+    @property
+    def converter_regexes(self) -> tuple[str, str]:
+        """Return regex like "uksc|ukftt" and "crim|civ" suitable for URL parsing in editor/public ui"""
+        params = tuple(itertools.chain.from_iterable([court.param_aliases for court in self.get_all()]))
+        court_set = set([court for param in params if (court := param.partition("/")[0])])
+        subdivision_set = set([subdivision for param in params if (subdivision := param.partition("/")[2])])
+        court_regex = "|".join(sorted(court_set))
+        subdivision_regex = "|".join(sorted(subdivision_set))
+        return (court_regex, subdivision_regex)
 
 
 yaml = YAML()

--- a/src/ds_caselaw_utils/test_courts.py
+++ b/src/ds_caselaw_utils/test_courts.py
@@ -387,6 +387,33 @@ class TestCourtsRepository(unittest.TestCase):
         assert institutions[0].type is InstitutionType.COURT
         assert institutions[1].type is InstitutionType.TRIBUNAL
 
+    def test_converter_regex(self):
+        data = [
+            {
+                "name": "court_group1",
+                "is_tribunal": False,
+                "courts": [{"param": "court1/jam", "name": "Court 1 Jam"}],
+            },
+            {
+                "name": "court_group2",
+                "is_tribunal": False,
+                "courts": [{"param": "court2/jam", "name": "Court 2 Jam"}],
+            },
+            {
+                "name": "court_group3",
+                "is_tribunal": False,
+                "courts": [{"param": "court2/eggs", "name": "Court 2 Eggs", "extra_params": ["court3/bacon"]}],
+            },
+            {
+                "name": "court_group4",
+                "is_tribunal": False,
+                "courts": [{"name": "Has no params"}],
+            },
+        ]
+        valid_data = make_court_repo_valid(data)
+        repo = CourtsRepository(valid_data)
+        assert repo.converter_regexes == ("court1|court2|court3", "bacon|eggs|jam")
+
 
 class TestCourt(unittest.TestCase):
     def test_repr_string(self):


### PR DESCRIPTION
Currently outputs

```
public: 'eat|ewca|ewcc|ewcop|ewcr|ewfc|ewhc|    ukait|ukftt|ukiptrib|      ukpc|uksc|ukut'
this..: 'eat|ewca|ewcc|ewcop|ewcr|ewfc|ewhc|ftt|ukait|ukftt|ukiptrib|ukist|ukpc|uksc|ukut'
editor: 'eat|ewca|ewcc|ewcop|ewcr|ewfc|ewhc|    ukait|ukftt|ukiptrib|      ukpc|uksc|ukut'
```

```
public: 'aac|admin|admlty|b|ch|civ|       comm|costs|       crim|       fam|grc|iac|ipec|kb|lc|mercantile|pat|       qb|scco|t1|t2|t3|tc|tcc'
this..: 'aac|admin|admlty|b|ch|civ|claims|comm|costs|credit|crim|estate|fam|grc|iac|ipec|kb|lc|mercantile|pat|pc|phl|qb|scco|t1|t2|t3|tc|tcc|transport'
editor: 'aac|admin|admlty|b|ch|civ|       comm|costs|       crim|       fam|grc|iac|ipec|kb|lc|mercantile|pat|       qb|scco|t1|t2|t3|tc|tcc'
```

