### PR TITLE
fix: fix incorrect property name in parser metadata schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 
 - **schema**: add new parserRunId property to parser metadata schema
 
+### Fix
+
+- fix incorrect property name in parser metadata schema
+
 ## v4.2.1 (2026-04-29)
 
 ### Fix

--- a/doc/schemas/parser-metadata/metadata-schema.md
+++ b/doc/schemas/parser-metadata/metadata-schema.md
@@ -2,7 +2,7 @@
 
 - [1. Property `Parsed document metadata > parameters`](#parameters)
   - [1.1. Property `Parsed document metadata > parameters > PARSER`](#parameters_PARSER)
-    - [1.1.1. Property `Parsed document metadata > parameters > PARSER > parserRunId`](#parameters_PARSER_parserRunId)
+    - [1.1.1. Property `Parsed document metadata > parameters > PARSER > parser_run_id`](#parameters_PARSER_parser_run_id)
     - [1.1.2. Property `Parsed document metadata > parameters > PARSER > documentType`](#parameters_PARSER_documentType)
     - [1.1.3. Property `Parsed document metadata > parameters > PARSER > uri`](#parameters_PARSER_uri)
     - [1.1.4. Property `Parsed document metadata > parameters > PARSER > court`](#parameters_PARSER_court)
@@ -94,7 +94,7 @@
 
 | Property                                                                       | Pattern | Type             | Deprecated | Definition | Title/Description                                                                                                                                                             |
 | ------------------------------------------------------------------------------ | ------- | ---------------- | ---------- | ---------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| - [parserRunId](#parameters_PARSER_parserRunId )                               | No      | string           | No         | -          | Parser run ID                                                                                                                                                                 |
+| - [parser_run_id](#parameters_PARSER_parser_run_id )                           | No      | string           | No         | -          | Parser run ID                                                                                                                                                                 |
 | + [documentType](#parameters_PARSER_documentType )                             | No      | enum (of string) | No         | -          | Type of document                                                                                                                                                              |
 | - [uri](#parameters_PARSER_uri )                                               | No      | string or null   | No         | -          | Document URI                                                                                                                                                                  |
 | - [court](#parameters_PARSER_court )                                           | No      | string           | No         | -          | Court                                                                                                                                                                         |
@@ -109,7 +109,7 @@
 | - [metadata_fields](#parameters_PARSER_metadata_fields )                       | No      | array of object  | No         | -          | Metadata fields                                                                                                                                                               |
 | - [xml_contains_document_text](#parameters_PARSER_xml_contains_document_text ) | No      | boolean          | No         | -          | An indicator of if the XML of the document contains body text which is renderable for human consumption, instead of only being a stub containing metadata for a static asset. |
 
-#### <a name="parameters_PARSER_parserRunId"></a>1.1.1. Property `Parsed document metadata > parameters > PARSER > parserRunId`
+#### <a name="parameters_PARSER_parser_run_id"></a>1.1.1. Property `Parsed document metadata > parameters > PARSER > parser_run_id`
 
 **Title:** Parser run ID
 

--- a/doc/schemas/parser-metadata/parser-schema.md
+++ b/doc/schemas/parser-metadata/parser-schema.md
@@ -1,6 +1,6 @@
 # Parser process metadata
 
-- [1. Property `Parser process metadata > parserRunId`](#parserRunId)
+- [1. Property `Parser process metadata > parser_run_id`](#parser_run_id)
 - [2. Property `Parser process metadata > documentType`](#documentType)
 - [3. Property `Parser process metadata > uri`](#uri)
 - [4. Property `Parser process metadata > court`](#court)
@@ -55,7 +55,7 @@
 
 | Property                                                     | Pattern | Type             | Deprecated | Definition | Title/Description                                                                                                                                                             |
 | ------------------------------------------------------------ | ------- | ---------------- | ---------- | ---------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| - [parserRunId](#parserRunId )                               | No      | string           | No         | -          | Parser run ID                                                                                                                                                                 |
+| - [parser_run_id](#parser_run_id )                           | No      | string           | No         | -          | Parser run ID                                                                                                                                                                 |
 | + [documentType](#documentType )                             | No      | enum (of string) | No         | -          | Type of document                                                                                                                                                              |
 | - [uri](#uri )                                               | No      | string or null   | No         | -          | Document URI                                                                                                                                                                  |
 | - [court](#court )                                           | No      | string           | No         | -          | Court                                                                                                                                                                         |
@@ -70,7 +70,7 @@
 | - [metadata_fields](#metadata_fields )                       | No      | array of object  | No         | -          | Metadata fields                                                                                                                                                               |
 | - [xml_contains_document_text](#xml_contains_document_text ) | No      | boolean          | No         | -          | An indicator of if the XML of the document contains body text which is renderable for human consumption, instead of only being a stub containing metadata for a static asset. |
 
-## <a name="parserRunId"></a>1. Property `Parser process metadata > parserRunId`
+## <a name="parser_run_id"></a>1. Property `Parser process metadata > parser_run_id`
 
 **Title:** Parser run ID
 

--- a/src/ds_caselaw_utils/schemas/parser-metadata/parser.schema.json
+++ b/src/ds_caselaw_utils/schemas/parser-metadata/parser.schema.json
@@ -4,7 +4,7 @@
   "title": "Parser process metadata",
   "description": "Metadata about a document or its processing which has been generated or collated as a result of the Find Case Law parsing process.",
   "properties": {
-    "parserRunId": {
+    "parser_run_id": {
       "title": "Parser run ID",
       "description": "A UUID to identify the parser run. This does not need to be unique per document; it should be unique per invocation of the parser.",
       "type": "string",

--- a/src/ds_caselaw_utils/types/metadata_schema_autogen.py
+++ b/src/ds_caselaw_utils/types/metadata_schema_autogen.py
@@ -95,7 +95,7 @@ ParserProcessMetadata = TypedDict('ParserProcessMetadata', {
     # | A UUID to identify the parser run. This does not need to be unique per document; it should be unique per invocation of the parser.
     # | 
     # | format: uuid
-    'parserRunId': str,
+    'parser_run_id': str,
     # | Type of document.
     # | 
     # | Required property


### PR DESCRIPTION
This property name was incorrectly given as the camel-cased `parserRunId`, instead of the correct lower-snake-case `parser_run_id`.