### PR TITLE
[FCLC-1982] Add error_on_existing_document to ingester options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+### Feat
+
+- **schemas**: add new INGESTER.error_on_existing_document option
+
 ## v4.3.1 (2026-05-13)
 
 ### Fix

--- a/doc/schemas/parser-metadata/ingester_options-schema.md
+++ b/doc/schemas/parser-metadata/ingester_options-schema.md
@@ -1,9 +1,10 @@
 # Ingester options
 
 - [1. Property `Ingester options > auto_publish`](#auto_publish)
-- [2. Property `Ingester options > source_document`](#source_document)
-  - [2.1. Property `Ingester options > source_document > format`](#source_document_format)
-  - [2.2. Property `Ingester options > source_document > file_hash`](#source_document_file_hash)
+- [2. Property `Ingester options > error_on_existing_document`](#error_on_existing_document)
+- [3. Property `Ingester options > source_document`](#source_document)
+  - [3.1. Property `Ingester options > source_document > format`](#source_document_format)
+  - [3.2. Property `Ingester options > source_document > file_hash`](#source_document_file_hash)
 
 **Title:** Ingester options
 
@@ -15,10 +16,11 @@
 
 **Description:** A set of options to be passed to the ingester, giving hints and instructions on processing behaviours.
 
-| Property                               | Pattern | Type    | Deprecated | Definition | Title/Description                                   |
-| -------------------------------------- | ------- | ------- | ---------- | ---------- | --------------------------------------------------- |
-| - [auto_publish](#auto_publish )       | No      | boolean | No         | -          | Auto-publish document                               |
-| - [source_document](#source_document ) | No      | object  | No         | -          | Information about the source file which was parsed. |
+| Property                                                     | Pattern | Type    | Deprecated | Definition | Title/Description                                   |
+| ------------------------------------------------------------ | ------- | ------- | ---------- | ---------- | --------------------------------------------------- |
+| - [auto_publish](#auto_publish )                             | No      | boolean | No         | -          | Auto-publish document                               |
+| - [error_on_existing_document](#error_on_existing_document ) | No      | boolean | No         | -          | Raise error on existing document                    |
+| - [source_document](#source_document )                       | No      | object  | No         | -          | Information about the source file which was parsed. |
 
 ## <a name="auto_publish"></a>1. Property `Ingester options > auto_publish`
 
@@ -32,7 +34,19 @@
 
 **Description:** Should the ingester bypass the editorial approval process and automatically publish this document?
 
-## <a name="source_document"></a>2. Property `Ingester options > source_document`
+## <a name="error_on_existing_document"></a>2. Property `Ingester options > error_on_existing_document`
+
+**Title:** Raise error on existing document
+
+|              |           |
+| ------------ | --------- |
+| **Type**     | `boolean` |
+| **Required** | No        |
+| **Default**  | `false`   |
+
+**Description:** Should the ingester raise an exception when it finds an existing document, instead of appending a new version?
+
+## <a name="source_document"></a>3. Property `Ingester options > source_document`
 
 |                           |                  |
 | ------------------------- | ---------------- |
@@ -47,7 +61,7 @@
 | + [format](#source_document_format )       | No      | string | No         | -          | Document format   |
 | + [file_hash](#source_document_file_hash ) | No      | string | No         | -          | File hash         |
 
-### <a name="source_document_format"></a>2.1. Property `Ingester options > source_document > format`
+### <a name="source_document_format"></a>3.1. Property `Ingester options > source_document > format`
 
 **Title:** Document format
 
@@ -58,7 +72,7 @@
 
 **Description:** The MIME type of the source file.
 
-### <a name="source_document_file_hash"></a>2.2. Property `Ingester options > source_document > file_hash`
+### <a name="source_document_file_hash"></a>3.2. Property `Ingester options > source_document > file_hash`
 
 **Title:** File hash
 

--- a/doc/schemas/parser-metadata/ingester_options-schema.md
+++ b/doc/schemas/parser-metadata/ingester_options-schema.md
@@ -28,6 +28,7 @@
 | ------------ | --------- |
 | **Type**     | `boolean` |
 | **Required** | No        |
+| **Default**  | `false`   |
 
 **Description:** Should the ingester bypass the editorial approval process and automatically publish this document?
 

--- a/doc/schemas/parser-metadata/metadata-schema.md
+++ b/doc/schemas/parser-metadata/metadata-schema.md
@@ -53,9 +53,10 @@
     - [1.1.14. Property `Document processing metadata > parameters > PARSER > xml_contains_document_text`](#parameters_PARSER_xml_contains_document_text)
   - [1.2. Property `Document processing metadata > parameters > INGESTER_OPTIONS`](#parameters_INGESTER_OPTIONS)
     - [1.2.1. Property `Document processing metadata > parameters > INGESTER_OPTIONS > auto_publish`](#parameters_INGESTER_OPTIONS_auto_publish)
-    - [1.2.2. Property `Document processing metadata > parameters > INGESTER_OPTIONS > source_document`](#parameters_INGESTER_OPTIONS_source_document)
-      - [1.2.2.1. Property `Document processing metadata > parameters > INGESTER_OPTIONS > source_document > format`](#parameters_INGESTER_OPTIONS_source_document_format)
-      - [1.2.2.2. Property `Document processing metadata > parameters > INGESTER_OPTIONS > source_document > file_hash`](#parameters_INGESTER_OPTIONS_source_document_file_hash)
+    - [1.2.2. Property `Document processing metadata > parameters > INGESTER_OPTIONS > error_on_existing_document`](#parameters_INGESTER_OPTIONS_error_on_existing_document)
+    - [1.2.3. Property `Document processing metadata > parameters > INGESTER_OPTIONS > source_document`](#parameters_INGESTER_OPTIONS_source_document)
+      - [1.2.3.1. Property `Document processing metadata > parameters > INGESTER_OPTIONS > source_document > format`](#parameters_INGESTER_OPTIONS_source_document_format)
+      - [1.2.3.2. Property `Document processing metadata > parameters > INGESTER_OPTIONS > source_document > file_hash`](#parameters_INGESTER_OPTIONS_source_document_file_hash)
   - [1.3. Property `Document processing metadata > parameters > TDR`](#parameters_TDR)
   - [1.4. Property `Document processing metadata > parameters > TRE`](#parameters_TRE)
 
@@ -747,10 +748,11 @@ Must be one of:
 
 **Description:** A set of options to be passed to the ingester, giving hints and instructions on processing behaviours.
 
-| Property                                                           | Pattern | Type    | Deprecated | Definition | Title/Description                                   |
-| ------------------------------------------------------------------ | ------- | ------- | ---------- | ---------- | --------------------------------------------------- |
-| - [auto_publish](#parameters_INGESTER_OPTIONS_auto_publish )       | No      | boolean | No         | -          | Auto-publish document                               |
-| - [source_document](#parameters_INGESTER_OPTIONS_source_document ) | No      | object  | No         | -          | Information about the source file which was parsed. |
+| Property                                                                                 | Pattern | Type    | Deprecated | Definition | Title/Description                                   |
+| ---------------------------------------------------------------------------------------- | ------- | ------- | ---------- | ---------- | --------------------------------------------------- |
+| - [auto_publish](#parameters_INGESTER_OPTIONS_auto_publish )                             | No      | boolean | No         | -          | Auto-publish document                               |
+| - [error_on_existing_document](#parameters_INGESTER_OPTIONS_error_on_existing_document ) | No      | boolean | No         | -          | Raise error on existing document                    |
+| - [source_document](#parameters_INGESTER_OPTIONS_source_document )                       | No      | object  | No         | -          | Information about the source file which was parsed. |
 
 #### <a name="parameters_INGESTER_OPTIONS_auto_publish"></a>1.2.1. Property `Document processing metadata > parameters > INGESTER_OPTIONS > auto_publish`
 
@@ -764,7 +766,19 @@ Must be one of:
 
 **Description:** Should the ingester bypass the editorial approval process and automatically publish this document?
 
-#### <a name="parameters_INGESTER_OPTIONS_source_document"></a>1.2.2. Property `Document processing metadata > parameters > INGESTER_OPTIONS > source_document`
+#### <a name="parameters_INGESTER_OPTIONS_error_on_existing_document"></a>1.2.2. Property `Document processing metadata > parameters > INGESTER_OPTIONS > error_on_existing_document`
+
+**Title:** Raise error on existing document
+
+|              |           |
+| ------------ | --------- |
+| **Type**     | `boolean` |
+| **Required** | No        |
+| **Default**  | `false`   |
+
+**Description:** Should the ingester raise an exception when it finds an existing document, instead of appending a new version?
+
+#### <a name="parameters_INGESTER_OPTIONS_source_document"></a>1.2.3. Property `Document processing metadata > parameters > INGESTER_OPTIONS > source_document`
 
 |                           |                  |
 | ------------------------- | ---------------- |
@@ -779,7 +793,7 @@ Must be one of:
 | + [format](#parameters_INGESTER_OPTIONS_source_document_format )       | No      | string | No         | -          | Document format   |
 | + [file_hash](#parameters_INGESTER_OPTIONS_source_document_file_hash ) | No      | string | No         | -          | File hash         |
 
-##### <a name="parameters_INGESTER_OPTIONS_source_document_format"></a>1.2.2.1. Property `Document processing metadata > parameters > INGESTER_OPTIONS > source_document > format`
+##### <a name="parameters_INGESTER_OPTIONS_source_document_format"></a>1.2.3.1. Property `Document processing metadata > parameters > INGESTER_OPTIONS > source_document > format`
 
 **Title:** Document format
 
@@ -790,7 +804,7 @@ Must be one of:
 
 **Description:** The MIME type of the source file.
 
-##### <a name="parameters_INGESTER_OPTIONS_source_document_file_hash"></a>1.2.2.2. Property `Document processing metadata > parameters > INGESTER_OPTIONS > source_document > file_hash`
+##### <a name="parameters_INGESTER_OPTIONS_source_document_file_hash"></a>1.2.3.2. Property `Document processing metadata > parameters > INGESTER_OPTIONS > source_document > file_hash`
 
 **Title:** File hash
 

--- a/doc/schemas/parser-metadata/metadata-schema.md
+++ b/doc/schemas/parser-metadata/metadata-schema.md
@@ -760,6 +760,7 @@ Must be one of:
 | ------------ | --------- |
 | **Type**     | `boolean` |
 | **Required** | No        |
+| **Default**  | `false`   |
 
 **Description:** Should the ingester bypass the editorial approval process and automatically publish this document?
 

--- a/src/ds_caselaw_utils/schemas/parser-metadata/ingester_options.schema.json
+++ b/src/ds_caselaw_utils/schemas/parser-metadata/ingester_options.schema.json
@@ -10,6 +10,12 @@
       "type": "boolean",
       "default": false
     },
+    "error_on_existing_document": {
+      "title": "Raise error on existing document",
+      "description": "Should the ingester raise an exception when it finds an existing document, instead of appending a new version?",
+      "type": "boolean",
+      "default": false
+    },
     "source_document": {
       "description": "Information about the source file which was parsed.",
       "type": "object",

--- a/src/ds_caselaw_utils/schemas/parser-metadata/ingester_options.schema.json
+++ b/src/ds_caselaw_utils/schemas/parser-metadata/ingester_options.schema.json
@@ -7,7 +7,8 @@
     "auto_publish": {
       "title": "Auto-publish document",
       "description": "Should the ingester bypass the editorial approval process and automatically publish this document?",
-      "type": "boolean"
+      "type": "boolean",
+      "default": false
     },
     "source_document": {
       "description": "Information about the source file which was parsed.",

--- a/src/ds_caselaw_utils/types/metadata_schema_autogen.py
+++ b/src/ds_caselaw_utils/types/metadata_schema_autogen.py
@@ -1,6 +1,11 @@
 from typing import Any, Literal, Required, TypeAlias, TypedDict, Union
 
 
+AUTO_PUBLISH_DOCUMENT_DEFAULT = False
+r""" Default value of the field path 'Ingester options auto_publish' """
+
+
+
 ArrayOfAttachments = list["_ArrayOfAttachmentsItem"]
 r""" Array of attachments. """
 
@@ -53,6 +58,8 @@ class IngesterOptions(TypedDict, total=False):
     Auto-publish document.
 
     Should the ingester bypass the editorial approval process and automatically publish this document?
+
+    default: False
     """
 
     source_document: "_IngesterOptionsSourceDocument"

--- a/src/ds_caselaw_utils/types/metadata_schema_autogen.py
+++ b/src/ds_caselaw_utils/types/metadata_schema_autogen.py
@@ -62,6 +62,15 @@ class IngesterOptions(TypedDict, total=False):
     default: False
     """
 
+    error_on_existing_document: bool
+    r"""
+    Raise error on existing document.
+
+    Should the ingester raise an exception when it finds an existing document, instead of appending a new version?
+
+    default: False
+    """
+
     source_document: "_IngesterOptionsSourceDocument"
     r""" Information about the source file which was parsed. """
 
@@ -216,6 +225,11 @@ class PrimarySourceFile(TypedDict, total=False):
 
     Required property
     """
+
+
+
+RAISE_ERROR_ON_EXISTING_DOCUMENT_DEFAULT = False
+r""" Default value of the field path 'Ingester options error_on_existing_document' """
 
 
 


### PR DESCRIPTION
This will prompt the ingester to error out if it runs into an existing document with colliding identifiers, instead of appending a new version.