### PR TITLE
[FCLC-1886] Implement court relationships in the court data schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### Feat
+
+- support relationships between courts
+
 ### Fix
 
 - **schemas**: correctly title listable and selectable properties in court schema

--- a/doc/schemas/courts/courts-schema.md
+++ b/doc/schemas/courts/courts-schema.md
@@ -33,6 +33,10 @@
           - [1.4.1.17.1.1. Property `Raw Court Repository > Raw Court Group > courts > Raw Court > jurisdictions > Raw Jurisdiction > prefix`](#items_courts_items_jurisdictions_items_prefix)
           - [1.4.1.17.1.2. Property `Raw Court Repository > Raw Court Group > courts > Raw Court > jurisdictions > Raw Jurisdiction > name`](#items_courts_items_jurisdictions_items_name)
           - [1.4.1.17.1.3. Property `Raw Court Repository > Raw Court Group > courts > Raw Court > jurisdictions > Raw Jurisdiction > code`](#items_courts_items_jurisdictions_items_code)
+      - [1.4.1.18. Property `Raw Court Repository > Raw Court Group > courts > Raw Court > relationships`](#items_courts_items_relationships)
+        - [1.4.1.18.1. Raw Court Repository > Raw Court Group > courts > Raw Court > relationships > Court relationship](#items_courts_items_relationships_items)
+          - [1.4.1.18.1.1. Property `Raw Court Repository > Raw Court Group > courts > Raw Court > relationships > Court relationship > court_code`](#items_courts_items_relationships_items_court_code)
+          - [1.4.1.18.1.2. Property `Raw Court Repository > Raw Court Group > courts > Raw Court > relationships > Court relationship > relationship_type`](#items_courts_items_relationships_items_relationship_type)
 
 **Title:** Raw Court Repository
 
@@ -123,23 +127,24 @@
 | **Additional properties** | Not allowed        |
 | **Defined in**            | court.schema.json# |
 
-| Property                                                | Pattern | Type            | Deprecated | Definition | Title/Description         |
-| ------------------------------------------------------- | ------- | --------------- | ---------- | ---------- | ------------------------- |
-| + [code](#items_courts_items_code )                     | No      | string          | No         | -          | Court Code                |
-| + [name](#items_courts_items_name )                     | No      | string          | No         | -          | Name                      |
-| - [long_name](#items_courts_items_long_name )           | No      | string          | No         | -          | Long Name                 |
-| - [grouped_name](#items_courts_items_grouped_name )     | No      | string          | No         | -          | -                         |
-| - [param](#items_courts_items_param )                   | No      | string          | No         | -          | Search parameter          |
-| - [extra_params](#items_courts_items_extra_params )     | No      | array of string | No         | -          | Extra parameters          |
-| - [ncn_pattern](#items_courts_items_ncn_pattern )       | No      | string          | No         | -          | Neutral Citation Pattern  |
-| - [ncn_examples](#items_courts_items_ncn_examples )     | No      | array of string | No         | -          | Neutral Citation examples |
-| + [link](#items_courts_items_link )                     | No      | string          | No         | -          | -                         |
-| - [identifier_iri](#items_courts_items_identifier_iri ) | No      | string          | No         | -          | -                         |
-| - [start_year](#items_courts_items_start_year )         | No      | integer         | No         | -          | Start year                |
-| - [end_year](#items_courts_items_end_year )             | No      | integer         | No         | -          | End year                  |
-| + [listable](#items_courts_items_listable )             | No      | boolean         | No         | -          | Listable                  |
-| + [selectable](#items_courts_items_selectable )         | No      | boolean         | No         | -          | Selectable                |
-| - [jurisdictions](#items_courts_items_jurisdictions )   | No      | array of object | No         | -          | -                         |
+| Property                                                | Pattern | Type            | Deprecated | Definition                              | Title/Description         |
+| ------------------------------------------------------- | ------- | --------------- | ---------- | --------------------------------------- | ------------------------- |
+| + [code](#items_courts_items_code )                     | No      | string          | No         | In ./court.schema.json#/$defs/CourtCode | Court Code                |
+| + [name](#items_courts_items_name )                     | No      | string          | No         | -                                       | Name                      |
+| - [long_name](#items_courts_items_long_name )           | No      | string          | No         | -                                       | Long Name                 |
+| - [grouped_name](#items_courts_items_grouped_name )     | No      | string          | No         | -                                       | -                         |
+| - [param](#items_courts_items_param )                   | No      | string          | No         | -                                       | Search parameter          |
+| - [extra_params](#items_courts_items_extra_params )     | No      | array of string | No         | -                                       | Extra parameters          |
+| - [ncn_pattern](#items_courts_items_ncn_pattern )       | No      | string          | No         | -                                       | Neutral Citation Pattern  |
+| - [ncn_examples](#items_courts_items_ncn_examples )     | No      | array of string | No         | -                                       | Neutral Citation examples |
+| + [link](#items_courts_items_link )                     | No      | string          | No         | -                                       | -                         |
+| - [identifier_iri](#items_courts_items_identifier_iri ) | No      | string          | No         | -                                       | -                         |
+| - [start_year](#items_courts_items_start_year )         | No      | integer         | No         | -                                       | Start year                |
+| - [end_year](#items_courts_items_end_year )             | No      | integer         | No         | -                                       | End year                  |
+| + [listable](#items_courts_items_listable )             | No      | boolean         | No         | -                                       | Listable                  |
+| + [selectable](#items_courts_items_selectable )         | No      | boolean         | No         | -                                       | Selectable                |
+| - [jurisdictions](#items_courts_items_jurisdictions )   | No      | array of object | No         | -                                       | -                         |
+| - [relationships](#items_courts_items_relationships )   | No      | array of object | No         | -                                       | Relationships             |
 
 | All of(Requirement)                    |
 | -------------------------------------- |
@@ -188,10 +193,11 @@
 
 **Title:** Court Code
 
-|              |          |
-| ------------ | -------- |
-| **Type**     | `string` |
-| **Required** | Yes      |
+|                |                                      |
+| -------------- | ------------------------------------ |
+| **Type**       | `string`                             |
+| **Required**   | Yes                                  |
+| **Defined in** | ./court.schema.json#/$defs/CourtCode |
 
 **Description:** A unique code (within Find Case Law) to identify this court entity. Courts which exist only as internal proxy entities should be prefixed with `TNA`.
 
@@ -445,6 +451,67 @@
 | ------------ | -------- |
 | **Type**     | `string` |
 | **Required** | Yes      |
+
+##### <a name="items_courts_items_relationships"></a>1.4.1.18. Property `Raw Court Repository > Raw Court Group > courts > Raw Court > relationships`
+
+**Title:** Relationships
+
+|              |                   |
+| ------------ | ----------------- |
+| **Type**     | `array of object` |
+| **Required** | No                |
+
+**Description:** Other courts which this court relates to.
+
+|                      | Array restrictions |
+| -------------------- | ------------------ |
+| **Min items**        | N/A                |
+| **Max items**        | N/A                |
+| **Items unicity**    | False              |
+| **Additional items** | False              |
+| **Tuple validation** | See below          |
+
+| Each item of this array must be                               | Description                                               |
+| ------------------------------------------------------------- | --------------------------------------------------------- |
+| [Court relationship](#items_courts_items_relationships_items) | An object describing the relationship between two courts. |
+
+###### <a name="items_courts_items_relationships_items"></a>1.4.1.18.1. Raw Court Repository > Raw Court Group > courts > Raw Court > relationships > Court relationship
+
+**Title:** Court relationship
+
+|                           |                  |
+| ------------------------- | ---------------- |
+| **Type**                  | `object`         |
+| **Required**              | No               |
+| **Additional properties** | Any type allowed |
+
+**Description:** An object describing the relationship between two courts.
+
+| Property                                                                          | Pattern | Type             | Deprecated | Definition                                | Title/Description |
+| --------------------------------------------------------------------------------- | ------- | ---------------- | ---------- | ----------------------------------------- | ----------------- |
+| + [court_code](#items_courts_items_relationships_items_court_code )               | No      | string           | No         | Same as [code](#items_courts_items_code ) | Court Code        |
+| - [relationship_type](#items_courts_items_relationships_items_relationship_type ) | No      | enum (of string) | No         | -                                         | -                 |
+
+###### <a name="items_courts_items_relationships_items_court_code"></a>1.4.1.18.1.1. Property `Raw Court Repository > Raw Court Group > courts > Raw Court > relationships > Court relationship > court_code`
+
+**Title:** Court Code
+
+|                        |                                  |
+| ---------------------- | -------------------------------- |
+| **Type**               | `string`                         |
+| **Required**           | Yes                              |
+| **Same definition as** | [code](#items_courts_items_code) |
+
+###### <a name="items_courts_items_relationships_items_relationship_type"></a>1.4.1.18.1.2. Property `Raw Court Repository > Raw Court Group > courts > Raw Court > relationships > Court relationship > relationship_type`
+
+|              |                    |
+| ------------ | ------------------ |
+| **Type**     | `enum (of string)` |
+| **Required** | No                 |
+
+Must be one of:
+* "hears_appeals_from"
+* "hears_similar_cases_to"
 
 ----------------------------------------------------------------------------------------------------------------------------
 Generated using [json-schema-for-humans](https://github.com/coveooss/json-schema-for-humans)

--- a/src/ds_caselaw_utils/courts.py
+++ b/src/ds_caselaw_utils/courts.py
@@ -5,6 +5,7 @@ Get metadata for the courts covered by the service
 """
 
 import pathlib
+from dataclasses import dataclass
 from datetime import date
 from enum import Enum
 from functools import cached_property
@@ -16,6 +17,7 @@ from mdit_py_plugins.attrs import attrs_plugin
 from ruamel.yaml import YAML
 
 from ds_caselaw_utils.types.courts_schema_autogen import (
+    CourtRelationship,
     RawCourt,
     RawCourtRepository,
     RawJurisdiction,
@@ -31,9 +33,22 @@ class FormatMapDict(dict[str, Any]):
         return "{" + key + "}"
 
 
+@dataclass
+class CourtRelationshipObject:
+    court: "Court"
+    relationship_type: "RelationshipType"
+
+
 class InstitutionType(Enum):
     COURT = "court"
     TRIBUNAL = "tribunal"
+
+
+class RelationshipType(Enum):
+    """This maintains the mapping between types of relationship in the Court class and the enumerated types in the schema."""
+
+    HEARS_APPEALS_FROM = "hears_appeals_from"
+    SIMILAR_CASES_TO = "hears_similar_cases_to"
 
 
 class Jurisdiction:
@@ -73,6 +88,7 @@ class Court:
         self.jurisdictions: list[Jurisdiction] = [
             Jurisdiction(jurisdiction_data) for jurisdiction_data in data.get("jurisdictions", [])
         ]
+        self.relationships: list[CourtRelationship] = data.get("relationships") or []
 
     def get_jurisdiction(self, code: str) -> Optional[Jurisdiction]:
         return next((j for j in self.jurisdictions if j.code == code), None)
@@ -106,6 +122,29 @@ class Court:
     def historic_documents_support_text_as_html(self) -> Optional[str]:
         """Get support information (where present) on accessing historic court documents not held in FCL."""
         return self.render_markdown_text("historic_docs")
+
+    def relationships_of_type(self, relationship_type: RelationshipType) -> list[CourtRelationshipObject]:
+        relationships: list[CourtRelationshipObject] = [
+            CourtRelationshipObject(
+                court=courts.get_by_code(CourtCode(relationship["court_code"])),
+                relationship_type=RelationshipType(relationship["relationship_type"]),
+            )
+            for relationship in self.relationships
+            if relationship["relationship_type"] == relationship_type.value
+        ]
+
+        return relationships
+
+    def _relationships_to_courts(self, relationships: list[CourtRelationshipObject]) -> list["Court"]:
+        return [relationship.court for relationship in relationships]
+
+    @cached_property
+    def hears_appeals_from(self) -> list["Court"]:
+        return self._relationships_to_courts(self.relationships_of_type(RelationshipType.HEARS_APPEALS_FROM))
+
+    @cached_property
+    def hears_similar_cases_to(self) -> list["Court"]:
+        return self._relationships_to_courts(self.relationships_of_type(RelationshipType.SIMILAR_CASES_TO))
 
     def __repr__(self) -> str:
         return self.name

--- a/src/ds_caselaw_utils/schemas/courts/court.schema.json
+++ b/src/ds_caselaw_utils/schemas/courts/court.schema.json
@@ -1,13 +1,19 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$defs": {
+    "CourtCode": {
+      "title": "Court Code",
+      "type": "string",
+      "pattern": "^[A-Za-z]{2,}(-[A-Za-z0-9]+)*$"
+    }
+  },
   "type": "object",
   "title": "Raw Court",
   "properties": {
     "code": {
       "title": "Court Code",
       "description": "A unique code (within Find Case Law) to identify this court entity. Courts which exist only as internal proxy entities should be prefixed with `TNA`.",
-      "type": "string",
-      "pattern": "^[A-Za-z]{2,}(-[A-Za-z0-9]+)*$"
+      "$ref": "./court.schema.json#/$defs/CourtCode"
     },
     "name": {
       "title": "Name",
@@ -100,6 +106,26 @@
         },
         "required": ["prefix", "name", "code"],
         "additionalProperties": false
+      }
+    },
+    "relationships": {
+      "title": "Relationships",
+      "description": "Other courts which this court relates to.",
+      "type": "array",
+      "items": {
+        "title": "Court relationship",
+        "description": "An object describing the relationship between two courts.",
+        "type": "object",
+        "properties": {
+          "court_code": {
+            "$ref": "./court.schema.json#/$defs/CourtCode"
+          },
+          "relationship_type": {
+            "type": "string",
+            "enum": ["hears_appeals_from", "hears_similar_cases_to"]
+          }
+        },
+        "required": ["court_code"]
       }
     }
   },

--- a/src/ds_caselaw_utils/tests/test_court.py
+++ b/src/ds_caselaw_utils/tests/test_court.py
@@ -6,6 +6,7 @@ from ds_caselaw_utils.courts import (
     Court,
     CourtWithJurisdiction,
     InstitutionType,
+    RelationshipType,
 )
 from ds_caselaw_utils.tests.factory import CourtFactory
 
@@ -126,6 +127,55 @@ class TestCourt(unittest.TestCase):
 
         assert court.historic_documents_support_text_as_html == "<p>Support text.</p>"
         mock_render.assert_called_once_with("historic_docs")
+
+    def test_relationships_default_to_empty(self):
+        court = CourtFactory({})
+        self.assertEqual([], court.relationships)
+        self.assertEqual([], court.hears_appeals_from)
+        self.assertEqual([], court.hears_similar_cases_to)
+
+    @patch("ds_caselaw_utils.courts.courts.get_by_code")
+    def test_relationships_of_type_filters_by_relationship_type(self, mock_get_by_code):
+        related_court = CourtFactory({"code": "EWHC", "name": "High Court"})
+        mock_get_by_code.return_value = related_court
+
+        court = CourtFactory(
+            {
+                "relationships": [
+                    {"court_code": "EWHC", "relationship_type": "hears_appeals_from"},
+                    {"court_code": "EWCA", "relationship_type": "hears_similar_cases_to"},
+                ]
+            }
+        )
+
+        relationships = court.relationships_of_type(RelationshipType.HEARS_APPEALS_FROM)
+
+        self.assertEqual(1, len(relationships))
+        self.assertEqual("EWHC", relationships[0].court.code)
+        self.assertEqual(RelationshipType.HEARS_APPEALS_FROM, relationships[0].relationship_type)
+        mock_get_by_code.assert_called_once_with("EWHC")
+
+    @patch("ds_caselaw_utils.courts.Court.relationships_of_type")
+    def test_hears_appeals_from_returns_related_courts(self, mock_relationships_of_type):
+        related_court = CourtFactory({"code": "EWHC", "name": "High Court"})
+        mock_relationship = MagicMock(court=related_court)
+        mock_relationships_of_type.return_value = [mock_relationship]
+
+        court = CourtFactory({})
+
+        assert court.hears_appeals_from == [related_court]
+        mock_relationships_of_type.assert_called_once_with(RelationshipType.HEARS_APPEALS_FROM)
+
+    @patch("ds_caselaw_utils.courts.Court.relationships_of_type")
+    def test_hears_similar_cases_to_returns_related_courts(self, mock_relationships_of_type):
+        related_court = CourtFactory({"code": "EWCA", "name": "Court of Appeal"})
+        mock_relationship = MagicMock(court=related_court)
+        mock_relationships_of_type.return_value = [mock_relationship]
+
+        court = CourtFactory({})
+
+        assert court.hears_similar_cases_to == [related_court]
+        mock_relationships_of_type.assert_called_once_with(RelationshipType.SIMILAR_CASES_TO)
 
 
 class TestCourtWithJurisdiction(unittest.TestCase):

--- a/src/ds_caselaw_utils/types/courts_schema_autogen.py
+++ b/src/ds_caselaw_utils/types/courts_schema_autogen.py
@@ -1,4 +1,32 @@
-from typing import Required, TypedDict
+from typing import Literal, Required, TypedDict
+
+
+CourtCode = str
+r"""
+Court Code.
+
+pattern: ^[A-Za-z]{2,}(-[A-Za-z0-9]+)*$
+"""
+
+
+
+class CourtRelationship(TypedDict, total=False):
+    r"""
+    Court relationship.
+
+    An object describing the relationship between two courts.
+    """
+
+    court_code: Required["CourtCode"]
+    r"""
+    Court Code.
+
+    pattern: ^[A-Za-z]{2,}(-[A-Za-z0-9]+)*$
+
+    Required property
+    """
+
+    relationship_type: "_CourtRelationshipRelationshipType"
 
 
 NeutralCitationNumber = str
@@ -40,11 +68,9 @@ class RawCourt(TypedDict, total=False):
           - param
     """
 
-    code: Required[str]
+    code: Required["CourtCode"]
     r"""
     Court Code.
-
-    A unique code (within Find Case Law) to identify this court entity. Courts which exist only as internal proxy entities should be prefixed with `TNA`.
 
     pattern: ^[A-Za-z]{2,}(-[A-Za-z0-9]+)*$
 
@@ -143,6 +169,13 @@ class RawCourt(TypedDict, total=False):
     """
 
     jurisdictions: list["RawJurisdiction"]
+    relationships: list["CourtRelationship"]
+    r"""
+    Relationships.
+
+    Other courts which this court relates to.
+    """
+
 
 
 class RawCourtGroup(TypedDict, total=False):
@@ -182,6 +215,14 @@ class RawJurisdiction(TypedDict, total=False):
 
     code: Required[str]
     r""" Required property """
+
+
+
+_CourtRelationshipRelationshipType = Literal['hears_appeals_from'] | Literal['hears_similar_cases_to']
+_COURTRELATIONSHIPRELATIONSHIPTYPE_HEARS_APPEALS_FROM: Literal['hears_appeals_from'] = "hears_appeals_from"
+r"""The values for the '_CourtRelationshipRelationshipType' enum"""
+_COURTRELATIONSHIPRELATIONSHIPTYPE_HEARS_SIMILAR_CASES_TO: Literal['hears_similar_cases_to'] = "hears_similar_cases_to"
+r"""The values for the '_CourtRelationshipRelationshipType' enum"""
 
 
 


### PR DESCRIPTION
To support upcoming changes to court information pages we need to be able to store structured relationships between courts. This is implemented as a single flat list of relationships, with helper functions providing simplified access to relationships of a particular type.