### PR TITLE
chore: release v4.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
-## Unreleased
+## v4.8.0 (2026-07-28)
 
 ### Feat
 
 -- **courts**: Add UKFSMT (Financial Services Tribunal), UKPRT (Pensions Regulator Tribunal), UKSPC (Special Commissioners of Income Tax), and UKVAT (VAT and Duties Tribunal) historic tribunals
 
-## v4.7.0 (2026-07-25)
+## v4.7.0 (2026-06-25)
 
 ### Feat
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ds_caselaw_utils"
-version = "4.7.0"
+version = "4.8.0"
 description = "Utilities for the National Archives Caselaw project"
 authors = ["Nick Jackson <nick@dxw.com>", "David McKee <dragon@dxw.com>", "Tim Cowlishaw <tim@timcowlishaw.co.uk>", "Laura Porter <laura@dxw.com>"]
 license = "MIT"


### PR DESCRIPTION
This releases adds four historic tribunals.

- UKFSMT (Financial Services Tribunal)
- UKPRT (Pensions Regulator Tribunal)
- UKSPC (Special Commissioners of Income Tax)
- UKVAT (VAT and Duties Tribunal) historic tribunals